### PR TITLE
Use macOS machine for assemble Github Action steps

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -64,7 +64,7 @@ jobs:
 
   build:
     name: Assemble artifacts
-    runs-on: ubuntu-latest # TODO #16 Replace with macos-latest so the iOS frameworks a build too.
+    runs-on: macos-latest
     steps:
       - name: SCM
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog
 =========
 
 ## Version 1.0.0 *(In development)*
+Issue: [#16](https://github.com/maximbircu/devtools-library/issues/16)
+- Use macOS machine for the "assemble" Github Action step
+
 Issue: [#28](https://github.com/maximbircu/devtools-library/issues/28)
 - Implement JsonSchema reader
 - Add a JsonSchema source dev tools configuration screen to the Android sample app


### PR DESCRIPTION
Closes: #16 

- [x] Changelog <!-- Check this if you updated the changelog file  -->

### What has been done
Replaced `ubuntu-latest` with `macos-latest` to make the `assemble` CI step generate iOS frameworks.

### How to test
Make sure CI is ✅ 