### PR TITLE
Add Tool In-memory persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog
 =========
 
 ## Version 1.0.0 *(In development)*
+Issue: [#33](https://github.com/maximbircu/devtools-library/issues/33)
+- Add an in-memory persistence mechanism
+
 Issue: [#16](https://github.com/maximbircu/devtools-library/issues/16)
 - Use macOS machine for the "assemble" Github Action step
 

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/extensions/EditTextExtensions.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/extensions/EditTextExtensions.kt
@@ -1,0 +1,21 @@
+package com.maximbircu.devtools.android.extensions
+
+import android.text.Editable
+import android.text.TextWatcher
+import android.widget.EditText
+
+internal fun EditText.onTextChanged(listener: (text: String) -> Unit) {
+    addTextChangedListener(object : TextWatcher {
+        override fun afterTextChanged(s: Editable?) {
+            // We need to trigger the listener just on text changed
+        }
+
+        override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+            // We need to trigger the listener just on text changed
+        }
+
+        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+            listener(s.toString())
+        }
+    })
+}

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tool/DevToolLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tool/DevToolLayout.kt
@@ -2,7 +2,6 @@ package com.maximbircu.devtools.android.presentation.tool
 
 import android.content.Context
 import android.widget.RelativeLayout
-import androidx.annotation.CallSuper
 import com.maximbircu.devtools.android.R
 import com.maximbircu.devtools.android.extensions.makeInvisible
 import com.maximbircu.devtools.android.extensions.setEnabledRecursively
@@ -10,6 +9,7 @@ import com.maximbircu.devtools.android.extensions.show
 import com.maximbircu.devtools.common.core.DevTool
 import com.maximbircu.devtools.common.presentation.tool.DevToolPresenter
 import com.maximbircu.devtools.common.presentation.tool.DevToolView
+import kotlinx.android.synthetic.main.layout_dev_tool.view.devToolCard
 import kotlinx.android.synthetic.main.layout_dev_tool.view.devToolContentContainer
 import kotlinx.android.synthetic.main.layout_dev_tool_header.view.toolEnableToggle
 import kotlinx.android.synthetic.main.layout_dev_tool_header.view.toolTitle
@@ -20,29 +20,20 @@ abstract class DevToolLayout<T : DevTool<*>>(
 ) : RelativeLayout(context), DevToolView {
     abstract val layoutRes: Int
     private val presenter: DevToolPresenter = DevToolPresenter.create(this)
-    override val isToolEnabled: Boolean get() = toolEnableToggle.isChecked
 
     init {
         inflate(context, R.layout.layout_dev_tool, this)
         inflate(context, layoutRes, devToolContentContainer)
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    fun bind(tool: DevTool<*>) {
-        onBind(tool as T)
-        presenter.onToolBind(tool)
         toolEnableToggle.setOnCheckedChangeListener { _, isEnabled ->
             presenter.onToolEnableToggleUpdated(isEnabled)
         }
     }
 
-    @CallSuper
-    override fun persistToolState() {
-        presenter.onPersistToolState()
-        storeConfigValue()
+    @Suppress("UNCHECKED_CAST")
+    fun bind(tool: DevTool<*>) {
+        presenter.onToolBind(tool)
+        onBind(tool as T)
     }
-
-    abstract fun storeConfigValue()
 
     abstract fun onBind(tool: T)
 
@@ -50,8 +41,8 @@ abstract class DevToolLayout<T : DevTool<*>>(
 
     override fun hideEnableToggle() = toolEnableToggle.makeInvisible()
 
-    override fun setDevToolEnabled(isEnabled: Boolean) {
-        this.isEnabled = isEnabled
+    override fun setToolEnableState(isEnabled: Boolean) {
+        devToolCard.isEnabled = isEnabled
         toolEnableToggle.isChecked = isEnabled
         devToolContentContainer.setEnabledRecursively(isEnabled)
     }

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/GroupToolLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/GroupToolLayout.kt
@@ -17,7 +17,5 @@ class GroupToolLayout(context: Context) : DevToolLayout<GroupTool>(context), Gro
 
     override fun onBind(tool: GroupTool) = presenter.onToolBind(tool)
 
-    override fun storeConfigValue() = presenter.onStoreConfigurationValue()
-
     override fun showTools(tools: List<DevTool<*>>) = devToolsViewsContainer.showDevTools(tools)
 }

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enum/ChipGroupLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enum/ChipGroupLayout.kt
@@ -27,10 +27,8 @@ internal class ChipGroupLayout @JvmOverloads constructor(
     }
 
     fun setOnCheckedChangeListener(onChange: (String) -> Unit) {
-        setOnCheckedChangeListener { _, _ -> onChange(getCheckedChipData()) }
+        setOnCheckedChangeListener { _, _ -> onChange(chips.getValue(checkedChipId)) }
     }
-
-    fun getCheckedChipData(): String = chips.getValue(checkedChipId)
 
     fun getCheckedChip(): Chip = findViewById(checkedChipId)
 

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enum/EnumToolLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enum/EnumToolLayout.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.ViewTreeObserver.OnPreDrawListener
 import com.maximbircu.devtools.android.R
 import com.maximbircu.devtools.android.extensions.hide
+import com.maximbircu.devtools.android.extensions.onTextChanged
 import com.maximbircu.devtools.android.extensions.show
 import com.maximbircu.devtools.android.presentation.tool.DevToolLayout
 import com.maximbircu.devtools.common.presentation.tools.enum.EnumTool
@@ -16,15 +17,13 @@ import kotlinx.android.synthetic.main.layout_enum_tool.view.customValue
 class EnumToolLayout(context: Context) : DevToolLayout<EnumTool>(context), EnumToolView {
     private val presenter: EnumToolPresenter = EnumToolPresenter.create(this)
     override val layoutRes: Int get() = R.layout.layout_enum_tool
-    override val customOptionValue: String get() = customValue.text.toString()
 
     override fun onBind(tool: EnumTool) {
         presenter.onToolBind(tool)
-        chipGroup.setOnCheckedChangeListener(presenter::onOptionSelected)
         scrollToSelectedChipAfterPreDraw()
+        chipGroup.setOnCheckedChangeListener(presenter::onOptionSelected)
+        customValue.onTextChanged(presenter::onCustomValueChanged)
     }
-
-    override fun storeConfigValue() = presenter.onStoreConfigValue(chipGroup.getCheckedChipData())
 
     override fun showOptions(options: List<String>) = chipGroup.setChips(options)
 

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/text/TextToolLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/text/TextToolLayout.kt
@@ -2,6 +2,7 @@ package com.maximbircu.devtools.android.presentation.tools.text
 
 import android.content.Context
 import com.maximbircu.devtools.android.R
+import com.maximbircu.devtools.android.extensions.onTextChanged
 import com.maximbircu.devtools.android.presentation.tool.DevToolLayout
 import com.maximbircu.devtools.common.presentation.tools.text.TextTool
 import com.maximbircu.devtools.common.presentation.tools.text.TextToolPresenter
@@ -14,9 +15,10 @@ internal class TextToolLayout(context: Context) : DevToolLayout<TextTool>(contex
     private val presenter = TextToolPresenter.create(this)
     override val layoutRes get() = R.layout.layout_text_tool
 
-    override fun onBind(tool: TextTool) = presenter.onToolBind(tool)
-
-    override fun storeConfigValue() = presenter.onStoreConfigValue(editTextValue.text.toString())
+    override fun onBind(tool: TextTool) {
+        presenter.onToolBind(tool)
+        editTextValue.onTextChanged(presenter::onConfigValueChanged)
+    }
 
     override fun setHint(hint: String?) {
         inputLayout.hint = hint

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/time/TimeToolLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/time/TimeToolLayout.kt
@@ -1,7 +1,6 @@
 package com.maximbircu.devtools.android.presentation.tools.time
 
 import android.content.Context
-import android.view.View
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.maximbircu.devtools.android.R
 import com.maximbircu.devtools.android.presentation.tool.DevToolLayout
@@ -10,6 +9,7 @@ import com.maximbircu.devtools.common.presentation.tools.time.TimeTool
 import com.maximbircu.devtools.common.presentation.tools.time.TimeToolPresenter
 import com.maximbircu.devtools.common.presentation.tools.time.TimeToolView
 import kotlinx.android.synthetic.main.dialog_time_selection.view.timePicker
+import kotlinx.android.synthetic.main.layout_dev_tool.view.devToolCard
 import kotlinx.android.synthetic.main.layout_time_tool.view.timeText
 
 class TimeToolLayout(context: Context) : DevToolLayout<TimeTool>(context), TimeToolView {
@@ -19,21 +19,20 @@ class TimeToolLayout(context: Context) : DevToolLayout<TimeTool>(context), TimeT
 
     override fun onBind(tool: TimeTool) {
         presenter.onToolBind(tool)
-        rootView.setOnClickListener { presenter.onClick(currentSelectedTime) }
+        devToolCard.setOnClickListener { presenter.onClick(currentSelectedTime) }
     }
-
-    override fun storeConfigValue() = presenter.onStoreConfigValue(currentSelectedTime)
 
     override fun setTime(time: String) {
         timeText.text = time
     }
 
-    override fun displayTimeSelectionDialog(title: String?, time: String) {
-        val view = View.inflate(context, R.layout.dialog_time_selection, null)
-        val onPositiveButtonClick = { presenter.onTimeSelected(view.timePicker.time) }
+    override fun showTimePicker(title: String?, time: String) {
+        val view = inflate(context, R.layout.dialog_time_selection, null)
         view.timePicker.time = Time(time)
         MaterialAlertDialogBuilder(context)
-            .setPositiveButton(android.R.string.ok) { _, _ -> onPositiveButtonClick() }
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                presenter.onTimeSelected(view.timePicker.time)
+            }
             .setNegativeButton(android.R.string.cancel, null)
             .setView(view)
             .setTitle(title)

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/toggle/ToggleToolLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/toggle/ToggleToolLayout.kt
@@ -14,9 +14,12 @@ internal class ToggleToolLayout(
     private val presenter = ToggleToolPresenter.create(this)
     override val layoutRes: Int get() = R.layout.layout_toggle_tool
 
-    override fun onBind(tool: ToggleTool) = presenter.onToolBind(tool)
-
-    override fun storeConfigValue() = presenter.onStoreConfigValue(toggleValue.isChecked)
+    override fun onBind(tool: ToggleTool) {
+        presenter.onToolBind(tool)
+        toggleValue.setOnCheckedChangeListener { _, isChecked ->
+            presenter.onCheckedChangeListener(isChecked)
+        }
+    }
 
     override fun setValue(value: Boolean) {
         toggleValue.isChecked = value

--- a/devtools/android/src/main/res/layout/layout_dev_tool.xml
+++ b/devtools/android/src/main/res/layout/layout_dev_tool.xml
@@ -3,6 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginBottom="16dp"
+    android:id="@+id/devToolCard"
     android:theme="@style/Theme.DevTools"
     >
     <LinearLayout

--- a/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/extensions/EditTextExtensionsKtTest.kt
+++ b/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/extensions/EditTextExtensionsKtTest.kt
@@ -1,0 +1,68 @@
+package com.maximbircu.devtools.android.extensions
+
+import android.text.TextWatcher
+import android.widget.EditText
+import com.maximbircu.devtools.android.BaseTest
+import com.maximbircu.devtools.android.utils.mockk
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.mockkConstructor
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Test
+
+class EditTextExtensionsKtTest : BaseTest() {
+    @Test
+    fun `sets on text changed listener`() {
+        val editText: EditText = mockk()
+
+        editText.onTextChanged { }
+
+        verify { editText.addTextChangedListener(any()) }
+    }
+
+    @Test
+    fun `notifies listener on text change`() {
+        mockkConstructor(TextWatcher::class)
+        val listener: (String) -> Unit = mockk(relaxed = true)
+        val editText: EditText = mockk()
+        val textWatcherSlot = slot<TextWatcher>()
+        every { editText.addTextChangedListener(capture(textWatcherSlot)) } answers {
+            textWatcherSlot.captured.onTextChanged("Text", 0, 0, 0)
+        }
+
+        editText.onTextChanged(listener)
+
+        verify { listener("Text") }
+    }
+
+    @Test
+    fun `doesn't call the listener after text changed`() {
+        mockkConstructor(TextWatcher::class)
+        val listener: (String) -> Unit = mockk(relaxed = true)
+        val editText: EditText = mockk()
+        val textWatcherSlot = slot<TextWatcher>()
+        every { editText.addTextChangedListener(capture(textWatcherSlot)) } answers {
+            textWatcherSlot.captured.afterTextChanged(mockk())
+        }
+
+        editText.onTextChanged(listener)
+
+        verify { listener wasNot Called }
+    }
+
+    @Test
+    fun `doesn't call the listener before text changed`() {
+        mockkConstructor(TextWatcher::class)
+        val listener: (String) -> Unit = mockk(relaxed = true)
+        val editText: EditText = mockk()
+        val textWatcherSlot = slot<TextWatcher>()
+        every { editText.addTextChangedListener(capture(textWatcherSlot)) } answers {
+            textWatcherSlot.captured.beforeTextChanged("", 0, 0, 0)
+        }
+
+        editText.onTextChanged(listener)
+
+        verify { listener wasNot Called }
+    }
+}

--- a/devtools/common/src/androidMain/kotlin/com/maximbircu/devtools/common/SharedPreferencesProvider.kt
+++ b/devtools/common/src/androidMain/kotlin/com/maximbircu/devtools/common/SharedPreferencesProvider.kt
@@ -6,7 +6,8 @@ import android.content.SharedPreferences
 
 object SharedPreferencesProvider {
     private var appContext: Context? = null
-    private val application: Context get() = appContext ?: initAndGetAppCtxWithReflection()
+    private val application: Context
+        get() = appContext ?: initAndGetAppCtxWithReflection().also { appContext = it }
 
     fun getSharedPreferences(name: String): SharedPreferences {
         return application.getSharedPreferences(name, Context.MODE_PRIVATE)
@@ -15,8 +16,6 @@ object SharedPreferencesProvider {
     @SuppressLint("PrivateApi", "DiscouragedPrivateApi")
     private fun initAndGetAppCtxWithReflection(): Context {
         val activityThread = Class.forName("android.app.ActivityThread")
-        val ctx = activityThread.getDeclaredMethod("currentApplication").invoke(null) as Context
-        appContext = ctx
-        return ctx
+        return activityThread.getDeclaredMethod("currentApplication").invoke(null) as Context
     }
 }

--- a/devtools/common/src/androidMain/kotlin/com/maximbircu/devtools/common/stores/PreferencesToolStoreImpl.kt
+++ b/devtools/common/src/androidMain/kotlin/com/maximbircu/devtools/common/stores/PreferencesToolStoreImpl.kt
@@ -14,13 +14,9 @@ actual open class PreferencesToolStoreImpl<T : Any> actual constructor(
 
     override var isEnabled: Boolean
         set(value) { preferences.edit().putBoolean("${tool.key}_enabled", value).commit() }
-        get() = preferences.getBoolean("${tool.key}_enabled", tool.defaultEnabledValue)
+        get() = preferences.getBoolean("${tool.key}_enabled", tool.isEnabled)
 
-    override fun store(value: T) {
-        preferences.edit().put(tool.key, value).commit()
-    }
-
-    override fun restore(): T {
-        return preferences.get(tool.key, tool.getDefaultValue())
-    }
+    override var value: T
+        get() = preferences.get(tool.key, tool.getDefaultValue())
+        set(value) { preferences.edit().put(tool.key, value).commit() }
 }

--- a/devtools/common/src/androidTest/kotlin/com/maximbircu/devtools/common/SharedPreferencesProviderTest.kt
+++ b/devtools/common/src/androidTest/kotlin/com/maximbircu/devtools/common/SharedPreferencesProviderTest.kt
@@ -1,0 +1,30 @@
+package com.maximbircu.devtools.common
+
+import android.content.Context
+import android.content.Context.MODE_PRIVATE
+import android.content.SharedPreferences
+import com.maximbircu.devtools.common.mvp.BaseTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class SharedPreferencesProviderTest : BaseTest() {
+    @Test
+    fun `returns proper shared preferences`() {
+        mockkObject(SharedPreferencesProvider)
+        val expectedSharedPrefs: SharedPreferences = mockk(relaxed = true)
+        val context: Context = mockk(relaxed = true)
+        every { context.getSharedPreferences(any(), any()) } returns expectedSharedPrefs
+        every {
+            SharedPreferencesProvider invokeNoArgs "initAndGetAppCtxWithReflection"
+        } returns context
+
+        val actualSharedPrefs = SharedPreferencesProvider.getSharedPreferences("DevTools")
+
+        assertEquals(expectedSharedPrefs, actualSharedPrefs)
+        verify { context.getSharedPreferences("DevTools", MODE_PRIVATE) }
+    }
+}

--- a/devtools/common/src/androidTest/kotlin/com/maximbircu/devtools/common/stores/PreferencesToolStoreImplTest.kt
+++ b/devtools/common/src/androidTest/kotlin/com/maximbircu/devtools/common/stores/PreferencesToolStoreImplTest.kt
@@ -43,7 +43,7 @@ class PreferencesToolStoreImplTest : BaseTest() {
     fun `stores tool config value`() {
         val preferencesStore = createPreferencesStore(toolKey = "toggle-tool")
 
-        preferencesStore.store(true)
+        preferencesStore.value = true
 
         verify { sharedPrefsEditor.putBoolean("toggle-tool", true) }
     }
@@ -53,7 +53,7 @@ class PreferencesToolStoreImplTest : BaseTest() {
         val preferencesStore = createPreferencesStore(toolKey = "toggle-tool")
         every { sharedPrefs.getBoolean("toggle-tool", false) } returns true
 
-        assertTrue(preferencesStore.restore())
+        assertTrue(preferencesStore.value)
     }
 
     private fun createPreferencesStore(

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
@@ -1,9 +1,10 @@
 package com.maximbircu.devtools.common
 
 import com.maximbircu.devtools.common.core.reader.DevToolsSource
+import com.maximbircu.devtools.common.extensions.forEachRecursively
 
 /**
- * This interface serves as a facade for the library. It allows library consumers to manipulate the
+ * This interface serves as a facade for the library. It allows library consumers to manipulate
  * with the devtools states, and the configuration values they hold.
  */
 interface DevTools : DevToolsStorage {
@@ -12,6 +13,11 @@ interface DevTools : DevToolsStorage {
      * This function is invoked each time any of the configuration values are updated.
      */
     var onConfigUpdate: () -> Unit
+
+    /**
+     * Persists all dev tools configuration changes stored in memory.
+     */
+    fun persistToolsState()
 
     companion object {
         /**
@@ -34,4 +40,9 @@ interface DevTools : DevToolsStorage {
 private class DevToolsImpl(
     private val toolsStorage: DevToolsStorage,
     override var onConfigUpdate: () -> Unit
-) : DevTools, DevToolsStorage by toolsStorage
+) : DevTools, DevToolsStorage by toolsStorage {
+    override fun persistToolsState() {
+        tools.forEachRecursively { _, tool -> tool.persistState() }
+        onConfigUpdate()
+    }
+}

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevToolsStorage.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevToolsStorage.kt
@@ -42,9 +42,9 @@ class DevToolsStorageImpl(
     override val tools: Map<String, DevTool<*>>
 ) : DevToolsStorage {
     @Suppress("UNCHECKED_CAST")
-    override fun <T> getValue(key: String): T = getDevTool(key).store.restore() as T
+    override fun <T> getValue(key: String): T = getDevTool(key).value as T
 
-    override fun isEnabled(key: String): Boolean = getDevTool(key).store.isEnabled
+    override fun isEnabled(key: String): Boolean = getDevTool(key).isEnabled
 
     override fun getGroup(key: String): DevToolsStorage {
         return DevToolsStorageImpl((getDevTool(key) as GroupTool).tools)

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
@@ -10,29 +10,36 @@ import com.maximbircu.devtools.common.stores.PreferencesToolStoreImpl
  * @property title tool title displayed in the configuration screen
  * @property description short description of the dev tool configuration value
  * @property canBeDisabled the user can enable/disable the tool if true
- * @property defaultEnabledValue the default tool enable value if it can be enabled/disabled
+ * @property isEnabled true if the tool is enabled and false vice-versa
  */
-abstract class DevTool<T>(
+abstract class DevTool<T : Any>(
     var title: String? = null,
     var description: String = "",
     var canBeDisabled: Boolean = false,
-    var defaultEnabledValue: Boolean = true
+    var isEnabled: Boolean = true
 ) {
-    /**
-     * @return true if the tool is enabled and false vice-versa
-     */
-    val isEnabled: Boolean get() = store.isEnabled
+    private var _key: String? = null
+
+    var key: String
+        get() = _key ?: throw NullPointerException("Dev tool key was not set!")
+        set(value) {
+            _key = value
+            restorePersistedState()
+        }
 
     /**
-     * Unique dev tool id.
+     * The dev tool configuration value at the moment, note that this is kept just in memory and
+     * will not survive after [com.maximbircu.devtools.common.DevTools] recreation.
+     *
+     * You need to call [persistState] in case you need to persist it.
      */
-    lateinit var key: String
+    lateinit var value: T
 
     /**
      * Implements persistence logic of the tool and allows the persistence of the configuration
      * value the tool is manipulating, and its state.
      */
-    abstract val store: ToolStore<T>
+    protected abstract val store: ToolStore<T>
 
     /**
      * Provides a value which is used as a default config value till it will
@@ -43,6 +50,19 @@ abstract class DevTool<T>(
      * @return default configuration value
      */
     abstract fun getDefaultValue(): T
+
+    /**
+     * Persists the current in-memory stored configuration values.
+     */
+    fun persistState() {
+        store.value = value
+        store.isEnabled = isEnabled
+    }
+
+    private fun restorePersistedState() {
+        value = store.value
+        isEnabled = store.isEnabled
+    }
 }
 
 /**

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/ToolStore.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/ToolStore.kt
@@ -6,21 +6,14 @@ package com.maximbircu.devtools.common.core
  */
 interface ToolStore<T> {
     /**
+     * The dev tool enable state to be stored.
+     *
      * True if the tool is enabled and to false vice-versa.
      */
     var isEnabled: Boolean
 
     /**
-     * This method is called when a config value of a dev tool should be persisted.
-     *
-     * @param value configuration value which should be persisted
+     * The dev tool configuration value which will be stored.
      */
-    fun store(value: T)
-
-    /**
-     * This method provides the persisted value to the library.
-     *
-     * @return configuration value persisted by the [store] method
-     */
-    fun restore(): T
+    var value: T
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/extensions/DevToolExtensions.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/extensions/DevToolExtensions.kt
@@ -1,0 +1,13 @@
+package com.maximbircu.devtools.common.extensions
+
+import com.maximbircu.devtools.common.core.DevTool
+import com.maximbircu.devtools.common.presentation.tools.group.GroupTool
+
+internal fun Map<String, DevTool<*>>.forEachRecursively(action: (String, DevTool<*>) -> Unit) {
+    forEach { (key, tool) ->
+        if (tool is GroupTool) {
+            tool.tools.forEachRecursively(action)
+        }
+        action(key, tool)
+    }
+}

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenter.kt
@@ -14,9 +14,9 @@ interface ConfigScreenPresenter : Presenter {
     fun onCreate()
 
     /**
-     * Should be invoked when the user wants to apply the dev tools changes he made.
+     * Should be invoked when the user wants to apply the dev tools config changes he made.
      *
-     * Iterates through each tool view and makes it persist its state.
+     * Will notify the [DevTools] to persist the dev tools state.
      */
     fun onApplyConfig()
 
@@ -36,12 +36,7 @@ private class ConfigScreenPresenterImpl(
     private val devTools: DevTools,
     private val devToolsList: DevToolsListView
 ) : BasePresenter<ConfigScreenView>(view), ConfigScreenPresenter {
-    override fun onCreate() {
-        devToolsList.showDevTools(devTools.tools.values.toList())
-    }
+    override fun onCreate() = devToolsList.showDevTools(devTools.tools.values.toList())
 
-    override fun onApplyConfig() {
-        devToolsList.devToolViews.forEach { it.persistToolState() }
-        devTools.onConfigUpdate.invoke()
-    }
+    override fun onApplyConfig() = devTools.persistToolsState()
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenter.kt
@@ -6,24 +6,18 @@ import com.maximbircu.devtools.common.core.mvp.Presenter
 
 interface DevToolPresenter : Presenter {
     /**
-     * Should be called as soon as view receives its tool model.
+     * Should be called as soon as a [DevTool] instance has been provided
+     * to the [DevToolView].
      */
     fun onToolBind(tool: DevTool<*>)
 
     /**
      * Should be called whenever the user toggles the tool enable toggle.
      */
-    fun onToolEnableToggleUpdated(enabled: Boolean)
-
-    /**
-     * Should be called when the view receives the tool persist event.
-     */
-    fun onPersistToolState()
+    fun onToolEnableToggleUpdated(isEnabled: Boolean)
 
     companion object {
-        fun create(view: DevToolView): DevToolPresenter {
-            return DevToolPresenterImpl(view)
-        }
+        fun create(view: DevToolView): DevToolPresenter = DevToolPresenterImpl(view)
     }
 }
 
@@ -34,20 +28,17 @@ private class DevToolPresenterImpl(
 
     override fun onToolBind(tool: DevTool<*>) {
         this.tool = tool
-        setUpToolEnableToggle()
         view.setTitle(tool.title)
-        view.setDevToolEnabled(tool.isEnabled)
+        view.setToolEnableState(tool.isEnabled)
+        updateToolEnableToggleVisibility()
     }
 
-    override fun onToolEnableToggleUpdated(enabled: Boolean) {
-        view.setDevToolEnabled(enabled)
+    override fun onToolEnableToggleUpdated(isEnabled: Boolean) {
+        tool.isEnabled = isEnabled
+        view.setToolEnableState(isEnabled)
     }
 
-    override fun onPersistToolState() {
-        tool.store.isEnabled = view.isToolEnabled
-    }
-
-    private fun setUpToolEnableToggle() {
+    private fun updateToolEnableToggleVisibility() {
         if (tool.canBeDisabled) {
             view.showEnableToggle()
         } else {

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolView.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolView.kt
@@ -8,13 +8,6 @@ import com.maximbircu.devtools.common.core.mvp.BaseView
  */
 interface DevToolView : BaseView {
     /**
-     * The user should not be able to interact with the tool control if its not enabled.
-     *
-     * Should provide the tool enable/disable state.
-     */
-    val isToolEnabled: Boolean
-
-    /**
      * Should display the tool title to the user.
      */
     fun setTitle(title: String?)
@@ -35,12 +28,5 @@ interface DevToolView : BaseView {
      *
      * @param isEnabled true if the tool should be enabled and false vice-versa
      */
-    fun setDevToolEnabled(isEnabled: Boolean)
-
-    /**
-     * Should be called when the user triggers a configuration update.
-     *
-     * The implementation should persist the tool state when the method is invoked.
-     */
-    fun persistToolState()
+    fun setToolEnableState(isEnabled: Boolean)
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolPresenter.kt
@@ -17,33 +17,26 @@ interface EnumToolPresenter : Presenter {
     fun onToolBind(tool: EnumTool)
 
     /**
-     * Should be called as soon as a configuration update was triggered which happens whenever
-     * [com.maximbircu.devtools.common.presentation.tool.DevToolView.persistToolState] gets invoked.
-     *
-     * Will persist the [selectedOption] when called.
-     *
-     * @param selectedOption the selected configuration option at the invocation moment
-     */
-    fun onStoreConfigValue(selectedOption: String)
-
-    /**
-     * Should be called as soon as a new configuration option was selected.
-     *
-     * Will update the custom configuration value input field visibility if needed.
+     * Should be called as soon as a new configuration option is selected.
      *
      * @param option the selected configuration option at the invocation moment
      */
     fun onOptionSelected(option: String)
 
+    /**
+     * Should be called whenever the custom value input field text is changed.
+     *
+     * @param text the custom value input field new text
+     */
+    fun onCustomValueChanged(text: String)
+
     companion object {
-        fun create(view: EnumToolView): EnumToolPresenter {
-            /**
-             * Provides a new [EnumToolPresenter] instance.
-             *
-             * @param view a [EnumToolView] instance
-             */
-            return EnumToolPresenterImpl(view)
-        }
+        /**
+         * Provides a new [EnumToolPresenter] instance.
+         *
+         * @param view a [EnumToolView] instance
+         */
+        fun create(view: EnumToolView): EnumToolPresenter = EnumToolPresenterImpl(view)
     }
 }
 
@@ -51,35 +44,27 @@ private class EnumToolPresenterImpl(
     view: EnumToolView
 ) : BasePresenter<EnumToolView>(view), EnumToolPresenter {
     private lateinit var tool: EnumTool
-    private val selectedValue get() = tool.store.restore()
-    private val selectedValueKey get() = getOptionNameForValue(selectedValue) ?: CUSTOM_OPTION
 
     override fun onToolBind(tool: EnumTool) {
         this.tool = tool
         view.showOptions(getOptions())
-        view.setCustomValue(selectedValue)
+        view.setCustomValue(tool.value)
+        val selectedValueKey = getOptionNameForValue(tool.value) ?: CUSTOM_OPTION
         view.selectOption(selectedValueKey)
         onOptionSelected(selectedValueKey)
-    }
-
-    override fun onStoreConfigValue(selectedOption: String) {
-        tool.store.store(getValueForOption(selectedOption))
     }
 
     override fun onOptionSelected(option: String) {
         if (option == CUSTOM_OPTION) {
             view.showCustomValueInputView()
         } else {
+            tool.value = tool.options.getValue(option)
             view.hideCustomValueInputView()
         }
     }
 
-    private fun getValueForOption(option: String): String {
-        return if (option == CUSTOM_OPTION) {
-            view.customOptionValue
-        } else {
-            tool.options.getValue(option)
-        }
+    override fun onCustomValueChanged(text: String) {
+        tool.value = text
     }
 
     private fun getOptions(): List<String> {

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolView.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolView.kt
@@ -7,11 +7,6 @@ import com.maximbircu.devtools.common.core.mvp.BaseView
  */
 interface EnumToolView : BaseView {
     /**
-     * Should provide the value of the custom option input field at the invocation moment.
-     */
-    val customOptionValue: String
-
-    /**
      * Should present the list of the tool supported configuration options as
      * a single choice UI component.
      *

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolPresenter.kt
@@ -15,23 +15,13 @@ interface GroupToolPresenter : Presenter {
      */
     fun onToolBind(tool: GroupTool)
 
-    /**
-     * Should be called as soon as a configuration update was triggered which happens whenever
-     * [com.maximbircu.devtools.common.presentation.tool.DevToolView.persistToolState] gets invoked.
-     *
-     * Will notify all group tool members to persist their state.
-     */
-    fun onStoreConfigurationValue()
-
     companion object {
         /**
          * Provides a new [GroupToolPresenter] instance.
          *
          * @param view a [GroupToolView] instance
          */
-        fun create(view: GroupToolView): GroupToolPresenter {
-            return GroupToolPresenterImpl(view)
-        }
+        fun create(view: GroupToolView): GroupToolPresenter = GroupToolPresenterImpl(view)
     }
 }
 
@@ -40,9 +30,5 @@ private class GroupToolPresenterImpl(
 ) : BasePresenter<GroupToolView>(view), GroupToolPresenter {
     override fun onToolBind(tool: GroupTool) {
         view.showTools(tool.tools.values.toList())
-    }
-
-    override fun onStoreConfigurationValue() {
-        view.devToolsViews.forEach { toolView -> toolView.persistToolState() }
     }
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolStore.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolStore.kt
@@ -15,15 +15,5 @@ class GroupToolStore : PreferencesToolStore<Unit> {
      */
     override var isEnabled: Boolean = true
 
-    /**
-     * This action is not supported for [GroupTool] because the tool doesn't have any configuration
-     * value, thus we don't have what to store.
-     */
-    override fun store(value: Unit): Unit = throw UnsupportedOperationException()
-
-    /**
-     * This action is not supported for [GroupTool] because the tool doesn't have any configuration
-     * value, thus we don't have what to restore.
-     */
-    override fun restore(): Unit = throw UnsupportedOperationException()
+    override var value: Unit = Unit
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/text/TextToolPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/text/TextToolPresenter.kt
@@ -15,14 +15,11 @@ interface TextToolPresenter : Presenter {
     fun onToolBind(tool: TextTool)
 
     /**
-     * Should be called as soon as a configuration update was triggered which happens whenever
-     * [com.maximbircu.devtools.common.presentation.tool.DevToolView.persistToolState] gets invoked.
+     * Should be called whenever the configuration value is changed.
      *
-     * Will persist the [value] when called.
-     *
-     * @param value the configuration value presented at the invocation moment
+     * @param value the new configuration value
      */
-    fun onStoreConfigValue(value: String)
+    fun onConfigValueChanged(value: String)
 
     companion object {
         /**
@@ -43,16 +40,16 @@ private class TextToolPresenterImpl(
         this.tool = tool
         view.setHint(tool.hint)
         view.setInputDataType(tool.configurationValueType)
-        view.setTextValue(tool.store.restore().toString())
+        view.setTextValue(tool.value.toString())
     }
 
-    override fun onStoreConfigValue(value: String) {
+    override fun onConfigValueChanged(value: String) {
         when (tool.configurationValueType) {
-            String::class -> tool.store.store(value)
-            Int::class -> tool.store.store(value.toInt())
-            Long::class -> tool.store.store(value.toLong())
-            Float::class -> tool.store.store(value.toFloat())
-            Double::class -> tool.store.store(value.toDouble())
+            String::class -> tool.value = value
+            Int::class -> tool.value = value.toInt()
+            Long::class -> tool.value = value.toLong()
+            Float::class -> tool.value = value.toFloat()
+            Double::class -> tool.value = value.toDouble()
             else -> throw IllegalArgumentException(
                 "${tool.configurationValueType} type not supported"
             )

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/time/TimeToolPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/time/TimeToolPresenter.kt
@@ -15,16 +15,6 @@ interface TimeToolPresenter : Presenter {
     fun onToolBind(tool: TimeTool)
 
     /**
-     * Should be called as soon as a configuration update was triggered which happens whenever
-     * [com.maximbircu.devtools.common.presentation.tool.DevToolView.persistToolState] gets invoked.
-     *
-     * Will persist the [selectedTime] when called.
-     *
-     * @param selectedTime the time onfiguration value presented at the invocation moment
-     */
-    fun onStoreConfigValue(selectedTime: String)
-
-    /**
      * Should be called when the user selects the time tool UI element to update the time
      * configuration value.
      *
@@ -33,7 +23,7 @@ interface TimeToolPresenter : Presenter {
     fun onClick(selectedTime: String)
 
     /**
-     * Should be called as soon as a new time was selected.
+     * Should be called whenever a new time is selected.
      *
      * @param time the time configuration value presented at the invocation moment
      */
@@ -56,19 +46,15 @@ private class TimeToolPresenterImpl(
 
     override fun onToolBind(tool: TimeTool) {
         this.tool = tool
-        view.setTime(Time(tool.store.restore()).toString())
+        view.setTime(Time(tool.value).toString())
     }
 
     override fun onTimeSelected(time: Time) {
         view.setTime(time.toString())
+        tool.value = time.inMilliseconds()
     }
 
     override fun onClick(selectedTime: String) {
-        view.displayTimeSelectionDialog(tool.title, selectedTime)
-    }
-
-    override fun onStoreConfigValue(selectedTime: String) {
-        val newTime = Time(selectedTime).inMilliseconds()
-        tool.store.store(newTime)
+        view.showTimePicker(tool.title, selectedTime)
     }
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/time/TimeToolView.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/time/TimeToolView.kt
@@ -20,5 +20,5 @@ interface TimeToolView : BaseView {
      * @param title time dev tool title
      * @param time current time configuration value
      */
-    fun displayTimeSelectionDialog(title: String?, time: String)
+    fun showTimePicker(title: String?, time: String)
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/toggle/ToggleToolPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/toggle/ToggleToolPresenter.kt
@@ -16,14 +16,11 @@ interface ToggleToolPresenter : Presenter {
     fun onToolBind(tool: ToggleTool)
 
     /**
-     * Should be called as soon as a configuration update was triggered which happens whenever
-     * [com.maximbircu.devtools.common.presentation.tool.DevToolView.persistToolState] gets invoked.
+     * Should be called whenever the toggle value is changed.
      *
-     * Will persist the [value] when called.
-     *
-     * @param value the configuration value presented at the invocation moment
+     * @param isChecked the new value of the toggle
      */
-    fun onStoreConfigValue(value: Boolean)
+    fun onCheckedChangeListener(isChecked: Boolean)
 
     companion object {
         /**
@@ -42,10 +39,10 @@ private class ToggleToolPresenterImpl(
 
     override fun onToolBind(tool: ToggleTool) {
         this.tool = tool
-        view.setValue(tool.store.restore())
+        view.setValue(tool.value)
     }
 
-    override fun onStoreConfigValue(value: Boolean) {
-        tool.store.store(value)
+    override fun onCheckedChangeListener(isChecked: Boolean) {
+        tool.value = isChecked
     }
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaToolFactory.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaToolFactory.kt
@@ -15,7 +15,7 @@ internal abstract class JsonSchemaToolFactory<T : DevTool<*>>(
         title = jsonObject["title"]?.content
         description = jsonObject["description"]?.content ?: ""
         canBeDisabled = jsonObject["canBeDisabled"]?.boolean ?: true
-        defaultEnabledValue = jsonObject["defaultEnabledValue"]?.boolean ?: false
+        isEnabled = jsonObject["isEnabled"]?.boolean ?: false
     }
 
     protected abstract fun createDevTool(): T

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
@@ -1,0 +1,42 @@
+package com.maximbircu.devtools.common
+
+import com.maximbircu.devtools.common.core.createTool
+import com.maximbircu.devtools.common.extensions.forEachRecursively
+import com.maximbircu.devtools.common.mvp.BaseTest
+import com.maximbircu.devtools.common.presentation.tools.group.GroupTool
+import com.maximbircu.devtools.common.readers.DevToolsSources
+import com.maximbircu.devtools.common.readers.memory
+import com.maximbircu.devtools.common.utils.mockk
+import com.maximbircu.devtools.common.utils.returns
+import io.mockk.verify
+import kotlin.test.Test
+
+class DevToolsImplTest : BaseTest() {
+    @Test
+    fun `persists tools state`() {
+        val tools = mapOf(
+            "first-tool" to createTool(),
+            "second-tool" to createTool<GroupTool> {
+                ::tools returns mapOf("child-tool" to createTool())
+            }
+        )
+        val devTools = DevTools.create(DevToolsSources.memory(tools))
+
+        devTools.persistToolsState()
+
+        tools.forEachRecursively { _, tool -> verify { tool.persistState() } }
+    }
+
+    @Test
+    fun `notifies listeners about dev tools configuration update`() {
+        val onConfigUpdate: () -> Unit = mockk(relaxed = true)
+        val devTools = DevTools.create(
+            DevToolsSources.memory(emptyMap()),
+            onConfigUpdate = onConfigUpdate
+        )
+
+        devTools.persistToolsState()
+
+        verify { onConfigUpdate() }
+    }
+}

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsStorageImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsStorageImplTest.kt
@@ -15,10 +15,10 @@ import kotlin.test.assertTrue
 
 class DevToolsStorageImplTest : BaseTest() {
     @Test
-    fun `returns proper value for provided key`() {
+    fun `returns proper configuration value for provided key`() {
         val tools = mapOf<String, DevTool<*>>(
-            "first-toggle-tool" to createTool<ToggleTool> { store::restore returns false },
-            "text-tool" to createTool<TextTool> { store::restore returns "Text Value" }
+            "first-toggle-tool" to createTool<ToggleTool> { ::value returns false },
+            "text-tool" to createTool<TextTool> { ::value returns "Text Value" }
         )
 
         val storage: DevToolsStorage = DevToolsStorageImpl(tools)
@@ -30,8 +30,8 @@ class DevToolsStorageImplTest : BaseTest() {
     @Test
     fun `returns proper enabled value for provided key`() {
         val tools = mapOf<String, DevTool<*>>(
-            "first-toggle-tool" to createTool<ToggleTool> { store::isEnabled returns false },
-            "text-tool" to createTool<TextTool> { store::isEnabled returns true }
+            "first-toggle-tool" to createTool<ToggleTool> { ::isEnabled returns false },
+            "text-tool" to createTool<TextTool> { ::isEnabled returns true }
         )
 
         val storage: DevToolsStorage = DevToolsStorageImpl(tools)

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/core/DevToolFactory.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/core/DevToolFactory.kt
@@ -9,10 +9,7 @@ inline fun <reified T : DevTool<*>> createTool(mock: T.() -> Unit = {}): T {
     every { tool.title } returns null
     every { tool.description } returns ""
     every { tool.canBeDisabled } returns false
-    every { tool.defaultEnabledValue } returns true
-
-    every { tool.store } returns mockk(relaxed = true)
-    every { tool.store.isEnabled } returns false
+    every { tool.isEnabled } returns true
 
     mock(tool)
     return tool

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/extensions/DevToolExtensionsKtTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/extensions/DevToolExtensionsKtTest.kt
@@ -1,0 +1,25 @@
+package com.maximbircu.devtools.common.extensions
+
+import com.maximbircu.devtools.common.core.DevTool
+import com.maximbircu.devtools.common.core.createTool
+import com.maximbircu.devtools.common.presentation.tools.group.GroupTool
+import com.maximbircu.devtools.common.presentation.tools.text.TextTool
+import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
+import com.maximbircu.devtools.common.utils.mockk
+import io.mockk.verify
+import kotlin.test.Test
+
+class DevToolExtensionsKtTest {
+    @Test
+    fun `the action is invoked for each tool`() {
+        val listener: (String, DevTool<*>) -> Unit = mockk(relaxed = true)
+        val groupTool = GroupTool(mapOf("child-tool" to createTool<TextTool>()))
+        val tools = mapOf("first-tool" to ToggleTool(), "second-tool" to groupTool)
+
+        tools.forEachRecursively(listener)
+
+        verify { listener("first-tool", tools.getValue("first-tool")) }
+        verify { listener("second-tool", groupTool) }
+        verify { listener("child-tool", groupTool.tools.getValue("child-tool")) }
+    }
+}

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenterImplTest.kt
@@ -5,7 +5,6 @@ import com.maximbircu.devtools.common.core.DevTool
 import com.maximbircu.devtools.common.core.createTool
 import com.maximbircu.devtools.common.mvp.BasePresenterTest
 import com.maximbircu.devtools.common.presentation.list.DevToolsListView
-import com.maximbircu.devtools.common.presentation.tool.DevToolView
 import com.maximbircu.devtools.common.utils.mockk
 import io.mockk.every
 import io.mockk.verify
@@ -32,24 +31,9 @@ class ConfigScreenPresenterImplTest :
     }
 
     @Test
-    fun `triggers config update when the user applies config`() {
-        val devToolsViews = listOf<DevToolView>(mockk(), mockk(), mockk())
-        every { devTools.onConfigUpdate } returns mockk(relaxed = true)
-        every { devToolsList.devToolViews } returns devToolsViews
-
+    fun `persists tool state on apply config`() {
         presenter.onApplyConfig()
 
-        devToolsList.devToolViews.forEach { view -> verify { view.persistToolState() } }
-    }
-
-    @Test
-    fun `notifies listener about configuration update on apply`() {
-        val listener: () -> Unit = mockk(relaxed = true)
-        every { devTools.onConfigUpdate } returns listener
-        every { devToolsList.devToolViews } returns emptyList()
-
-        presenter.onApplyConfig()
-
-        verify { listener.invoke() }
+        devTools.persistToolsState()
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenterImplTest.kt
@@ -6,7 +6,6 @@ import com.maximbircu.devtools.common.presentation.tools.text.TextTool
 import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
 import com.maximbircu.devtools.common.utils.mockk
 import com.maximbircu.devtools.common.utils.returns
-import io.mockk.every
 import io.mockk.verify
 import kotlin.test.Test
 
@@ -14,7 +13,7 @@ class DevToolPresenterImplTest : BasePresenterTest<DevToolView, DevToolPresenter
     override fun createPresenter(): DevToolPresenter = DevToolPresenter.create(view)
 
     @Test
-    fun `sets title on bind`() {
+    fun `sets title on tool bind`() {
         val tool: ToggleTool = createTool { ::title returns "Toggle tool title" }
 
         presenter.onToolBind(tool)
@@ -23,7 +22,16 @@ class DevToolPresenterImplTest : BasePresenterTest<DevToolView, DevToolPresenter
     }
 
     @Test
-    fun `shows enable toggle if tool can be disabled on bind`() {
+    fun `sets tool enabled value on tool bind`() {
+        val tool: ToggleTool = createTool { ::isEnabled returns false }
+
+        presenter.onToolBind(tool)
+
+        verify { view.setToolEnableState(isEnabled = false) }
+    }
+
+    @Test
+    fun `shows enable toggle if tool can be disabled`() {
         val tool: ToggleTool = createTool { ::canBeDisabled returns true }
 
         presenter.onToolBind(tool)
@@ -32,7 +40,7 @@ class DevToolPresenterImplTest : BasePresenterTest<DevToolView, DevToolPresenter
     }
 
     @Test
-    fun `hides enable toggle if tool can not be disabled on bind`() {
+    fun `hides enable toggle if tool can not be disabled`() {
         val tool: ToggleTool = createTool { ::canBeDisabled returns false }
 
         presenter.onToolBind(tool)
@@ -41,29 +49,21 @@ class DevToolPresenterImplTest : BasePresenterTest<DevToolView, DevToolPresenter
     }
 
     @Test
-    fun `sets tool enabled value on bind`() {
-        val tool: ToggleTool = createTool { store::isEnabled returns false }
+    fun `sets tool enabled value on enable toggle update`() {
+        presenter.onToolBind(createTool())
 
-        presenter.onToolBind(tool)
-
-        verify { view.setDevToolEnabled(isEnabled = false) }
-    }
-
-    @Test
-    fun `sets tool enabled value on tool enable toggle updated`() {
         presenter.onToolEnableToggleUpdated(false)
 
-        verify { view.setDevToolEnabled(isEnabled = false) }
+        verify { view.setToolEnableState(isEnabled = false) }
     }
 
     @Test
-    fun `stores new tool enabled value on config updated`() {
-        val tool: TextTool = createTool { store::isEnabled returns false }
+    fun `updates tool enabled value on enable toggle update`() {
+        val tool: TextTool = createTool()
         presenter.onToolBind(tool)
-        every { view.isToolEnabled } returns true
 
-        presenter.onPersistToolState()
+        presenter.onToolEnableToggleUpdated(true)
 
-        verify { tool.store.isEnabled = true }
+        verify { tool.isEnabled = true }
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolPresenterImplTest.kt
@@ -4,11 +4,10 @@ import com.maximbircu.devtools.common.core.createTool
 import com.maximbircu.devtools.common.mvp.BasePresenterTest
 import com.maximbircu.devtools.common.utils.mockk
 import com.maximbircu.devtools.common.utils.returns
-import io.mockk.every
 import io.mockk.verify
 import kotlin.test.Test
 
-class EnumToolPresenterTest : BasePresenterTest<EnumToolView, EnumToolPresenter>(mockk()) {
+class EnumToolPresenterImplTest : BasePresenterTest<EnumToolView, EnumToolPresenter>(mockk()) {
     override fun createPresenter() = EnumToolPresenter.create(view)
 
     @Test
@@ -17,7 +16,7 @@ class EnumToolPresenterTest : BasePresenterTest<EnumToolView, EnumToolPresenter>
         val tool: EnumTool = createTool {
             ::allowCustom returns false
             ::options returns fakeOptions
-            store::restore returns "first-value"
+            ::value returns "first-value"
         }
 
         presenter.onToolBind(tool)
@@ -31,7 +30,7 @@ class EnumToolPresenterTest : BasePresenterTest<EnumToolView, EnumToolPresenter>
         val tool: EnumTool = createTool {
             ::allowCustom returns true
             ::options returns fakeOptions
-            store::restore returns "first-value"
+            ::value returns "first-value"
         }
 
         presenter.onToolBind(tool)
@@ -41,7 +40,7 @@ class EnumToolPresenterTest : BasePresenterTest<EnumToolView, EnumToolPresenter>
 
     @Test
     fun `sets custom value on tool bind`() {
-        val tool: EnumTool = createTool { store::restore returns "second-value" }
+        val tool: EnumTool = createTool { ::value returns "second-value" }
 
         presenter.onToolBind(tool)
 
@@ -53,7 +52,7 @@ class EnumToolPresenterTest : BasePresenterTest<EnumToolView, EnumToolPresenter>
         val fakeOptions = mapOf("first-option" to "first-value", "second-option" to "second-value")
         val tool: EnumTool = createTool {
             ::options returns fakeOptions
-            store::restore returns "second-value"
+            ::value returns "second-value"
         }
 
         presenter.onToolBind(tool)
@@ -66,7 +65,7 @@ class EnumToolPresenterTest : BasePresenterTest<EnumToolView, EnumToolPresenter>
         val fakeOptions = mapOf("first-option" to "first-value", "second-option" to "second-value")
         val tool: EnumTool = createTool {
             ::options returns fakeOptions
-            store::restore returns "some custom value"
+            ::value returns "some custom value"
         }
 
         presenter.onToolBind(tool)
@@ -75,7 +74,7 @@ class EnumToolPresenterTest : BasePresenterTest<EnumToolView, EnumToolPresenter>
     }
 
     @Test
-    fun `shows custom value input view if selected option is custom`() {
+    fun `shows custom value input if selected option is custom`() {
         presenter.onOptionSelected("custom")
 
         verify { view.showCustomValueInputView() }
@@ -83,39 +82,40 @@ class EnumToolPresenterTest : BasePresenterTest<EnumToolView, EnumToolPresenter>
 
     @Test
     fun `hides custom value input view if selected option is not custom`() {
+        presenter.onToolBind(createTool { ::value returns "some custom value" })
+
         presenter.onOptionSelected("second-option")
 
         verify { view.hideCustomValueInputView() }
     }
 
     @Test
-    fun `stores proper option value when the selected option is not custom`() {
+    fun `sets proper option value when the selected option is not custom`() {
         val fakeOptions = mapOf("first-option" to "first-value", "second-option" to "second-value")
         val tool: EnumTool = createTool {
             ::allowCustom returns true
             ::options returns fakeOptions
-            store::restore returns "second-value"
+            ::value returns "second-value"
         }
         presenter.onToolBind(tool)
 
-        presenter.onStoreConfigValue(selectedOption = "second-option")
+        presenter.onOptionSelected(option = "second-option")
 
-        verify { tool.store.store("second-value") }
+        verify { tool.value = "second-value" }
     }
 
     @Test
-    fun `stores proper option value when the selected option is custom`() {
+    fun `sets proper option value on custom value changes`() {
         val fakeOptions = mapOf("first-option" to "first-value", "second-option" to "second-value")
         val tool: EnumTool = createTool {
             ::allowCustom returns true
             ::options returns fakeOptions
-            store::restore returns "second-value"
+            ::value returns "second-value"
         }
         presenter.onToolBind(tool)
-        every { view.customOptionValue } returns "some custom value"
 
-        presenter.onStoreConfigValue(selectedOption = "custom")
+        presenter.onCustomValueChanged("some custom value")
 
-        verify { tool.store.store("some custom value") }
+        verify { tool.value = "some custom value" }
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolPresenterImplTest.kt
@@ -3,14 +3,12 @@ package com.maximbircu.devtools.common.presentation.tools.group
 import com.maximbircu.devtools.common.core.DevTool
 import com.maximbircu.devtools.common.core.createTool
 import com.maximbircu.devtools.common.mvp.BasePresenterTest
-import com.maximbircu.devtools.common.presentation.tool.DevToolView
 import com.maximbircu.devtools.common.utils.mockk
 import com.maximbircu.devtools.common.utils.returns
-import io.mockk.every
 import io.mockk.verify
 import kotlin.test.Test
 
-class GroupToolPresenterTest : BasePresenterTest<GroupToolView, GroupToolPresenter>(mockk()) {
+class GroupToolPresenterImplTest : BasePresenterTest<GroupToolView, GroupToolPresenter>(mockk()) {
     override fun createPresenter() = GroupToolPresenter.create(view)
 
     @Test
@@ -25,15 +23,5 @@ class GroupToolPresenterTest : BasePresenterTest<GroupToolView, GroupToolPresent
         presenter.onToolBind(tool)
 
         verify { view.showTools(fakeTools.values.toList()) }
-    }
-
-    @Test
-    fun `persists child tool state on store configuration value`() {
-        val fakeToolsViews = listOf<DevToolView>(mockk(), mockk(), mockk())
-        every { view.devToolsViews } returns fakeToolsViews
-
-        presenter.onStoreConfigurationValue()
-
-        fakeToolsViews.forEach { tool -> verify { tool.persistToolState() } }
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolStoreTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolStoreTest.kt
@@ -2,28 +2,21 @@ package com.maximbircu.devtools.common.presentation.tools.group
 
 import com.maximbircu.devtools.common.mvp.BaseTest
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class GroupToolStoreTest : BaseTest() {
     @Test
-    fun `returns always true for tool enabled value`() {
+    fun `returns always true as tool enabled value`() {
         val store = GroupToolStore()
 
         assertTrue(store.isEnabled)
     }
 
     @Test
-    fun `throws exception when trying to store something`() {
+    fun `returns always Unit as configuration value`() {
         val store = GroupToolStore()
 
-        assertFailsWith(UnsupportedOperationException::class) { store.store(Unit) }
-    }
-
-    @Test
-    fun `throws exception when trying to restore something`() {
-        val store = GroupToolStore()
-
-        assertFailsWith(UnsupportedOperationException::class) { store.restore() }
+        assertEquals(Unit, store.value)
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertFailsWith
 
 class GroupToolTest : BaseTest() {
     @Test
-    fun `throws exception if there was not tools provided`() {
+    fun `throws exception if there was no tools provided`() {
         val tool = GroupTool(mapOf())
 
         assertFailsWith(IllegalArgumentException::class) { tool.getDefaultValue() }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/text/TextToolPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/text/TextToolPresenterImplTest.kt
@@ -6,7 +6,7 @@ import com.maximbircu.devtools.common.utils.mockk
 import com.maximbircu.devtools.common.utils.returns
 import io.mockk.verify
 import kotlin.test.Test
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class TextToolPresenterImplTest : BasePresenterTest<TextToolView, TextToolPresenter>(mockk()) {
     override fun createPresenter(): TextToolPresenter = TextToolPresenter.create(view)
@@ -31,7 +31,7 @@ class TextToolPresenterImplTest : BasePresenterTest<TextToolView, TextToolPresen
 
     @Test
     fun `sets text value on tool bind`() {
-        val tool: TextTool = createTool { store::restore returns "text value" }
+        val tool: TextTool = createTool { ::value returns "text value" }
 
         presenter.onToolBind(tool)
 
@@ -41,53 +41,53 @@ class TextToolPresenterImplTest : BasePresenterTest<TextToolView, TextToolPresen
     // region Stores the proper config value
 
     @Test
-    fun `stores string value on store config value`() {
+    fun `sets string value on config value change`() {
         val tool: TextTool = createTool { ::configurationValueType returns String::class }
         presenter.onToolBind(tool)
 
-        presenter.onStoreConfigValue("text value")
+        presenter.onConfigValueChanged("text value")
 
-        verify { tool.store.store("text value") }
+        verify { tool.value = "text value" }
     }
 
     @Test
-    fun `stores int value on store config value`() {
+    fun `sets int value on config value change`() {
         val tool: TextTool = createTool { ::configurationValueType returns Int::class }
         presenter.onToolBind(tool)
 
-        presenter.onStoreConfigValue("3")
+        presenter.onConfigValueChanged("3")
 
-        verify { tool.store.store(3) }
+        verify { tool.value = 3 }
     }
 
     @Test
-    fun `stores long value on store config value`() {
+    fun `sets long value on config value change`() {
         val tool: TextTool = createTool { ::configurationValueType returns Long::class }
         presenter.onToolBind(tool)
 
-        presenter.onStoreConfigValue("3")
+        presenter.onConfigValueChanged("3")
 
-        verify { tool.store.store(3L) }
+        verify { tool.value = 3L }
     }
 
     @Test
-    fun `stores float value on store config value`() {
+    fun `sets float value on config value change`() {
         val tool: TextTool = createTool { ::configurationValueType returns Float::class }
         presenter.onToolBind(tool)
 
-        presenter.onStoreConfigValue("3")
+        presenter.onConfigValueChanged("3")
 
-        verify { tool.store.store(3f) }
+        verify { tool.value = 3f }
     }
 
     @Test
-    fun `stores double value on store config value`() {
+    fun `sets double value on config value change`() {
         val tool: TextTool = createTool { ::configurationValueType returns Double::class }
         presenter.onToolBind(tool)
 
-        presenter.onStoreConfigValue("3.0")
+        presenter.onConfigValueChanged("3.0")
 
-        verify { tool.store.store(3.0) }
+        verify { tool.value = 3.0 }
     }
 
     @Test
@@ -96,7 +96,9 @@ class TextToolPresenterImplTest : BasePresenterTest<TextToolView, TextToolPresen
         val tool: TextTool = createTool { ::configurationValueType returns value::class }
         presenter.onToolBind(tool)
 
-        assertFails { presenter.onStoreConfigValue(value.toString()) }
+        assertFailsWith(IllegalArgumentException::class) {
+            presenter.onConfigValueChanged(value.toString())
+        }
     }
 
     // endregion

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/time/TimeToolPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/time/TimeToolPresenterImplTest.kt
@@ -12,15 +12,20 @@ class TimeToolPresenterImplTest : BasePresenterTest<TimeToolView, TimeToolPresen
 
     @Test
     fun `sets time on tool bind`() {
-        val timeTool: TimeTool = createTool { store::restore returns 10000 }
+        val tool: TimeTool = createTool { ::value returns 10000 }
 
-        presenter.onToolBind(timeTool)
+        presenter.onToolBind(tool)
 
         verify { view.setTime("0d 0h 0m 10s 0ms") }
     }
 
     @Test
     fun `sets time when new time selected`() {
+        presenter.onToolBind(createTool {
+            ::title returns "Time Tool"
+            ::value returns 10000
+        })
+
         presenter.onTimeSelected(Time("1d 2h 3m 4s 5ms"))
 
         verify { view.setTime("1d 2h 3m 4s 5ms") }
@@ -28,24 +33,23 @@ class TimeToolPresenterImplTest : BasePresenterTest<TimeToolView, TimeToolPresen
 
     @Test
     fun `displays time selection dialog on click`() {
-        val timeTool: TimeTool = createTool {
+        presenter.onToolBind(createTool {
             ::title returns "Time Tool"
-            store::restore returns 10000
-        }
-        presenter.onToolBind(timeTool)
+            ::value returns 10000
+        })
 
         presenter.onClick("1d 2h 3m 4s 5ms")
 
-        verify { view.displayTimeSelectionDialog(title = "Time Tool", time = "1d 2h 3m 4s 5ms") }
+        verify { view.showTimePicker(title = "Time Tool", time = "1d 2h 3m 4s 5ms") }
     }
 
     @Test
-    fun `stores selected time on store config value`() {
-        val timeTool: TimeTool = createTool { store::restore returns 10000 }
+    fun `sets selected time on new time selected`() {
+        val timeTool: TimeTool = createTool { ::value returns 10000 }
         presenter.onToolBind(timeTool)
 
-        presenter.onStoreConfigValue("0d 0h 0m 10s 0ms")
+        presenter.onTimeSelected(Time("0d 0h 0m 10s 0ms"))
 
-        verify { timeTool.store.store(10000) }
+        verify { timeTool.value = 10000 }
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/toggle/ToggleToolPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/toggle/ToggleToolPresenterImplTest.kt
@@ -13,7 +13,7 @@ class ToggleToolPresenterImplTest :
 
     @Test
     fun `sets tool stored configuration value on tool bind`() {
-        val tool: ToggleTool = createTool { store::restore returns false }
+        val tool: ToggleTool = createTool { ::value returns false }
 
         presenter.onToolBind(tool)
 
@@ -21,12 +21,12 @@ class ToggleToolPresenterImplTest :
     }
 
     @Test
-    fun `stores new configuration value on update`() {
-        val tool: ToggleTool = createTool { store::restore returns false }
+    fun `sets new configuration value on toggle value update`() {
+        val tool: ToggleTool = createTool { ::value returns false }
         presenter.onToolBind(tool)
 
-        presenter.onStoreConfigValue(true)
+        presenter.onCheckedChangeListener(true)
 
-        verify { tool.store.store(true) }
+        verify { tool.value = true }
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaToolFactoryTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaToolFactoryTest.kt
@@ -16,7 +16,7 @@ class JsonSchemaToolFactoryTest : BaseTest() {
             "title" to "Tool title"
             "description" to "Tool description"
             "canBeDisabled" to false
-            "defaultEnabledValue" to true
+            "isEnabled" to true
         }
         val factory = JsonSchemaToolFactoryStub(jsonObject)
 
@@ -25,7 +25,7 @@ class JsonSchemaToolFactoryTest : BaseTest() {
         assertEquals("Tool title", tool.title)
         assertEquals("Tool description", tool.description)
         assertFalse(tool.canBeDisabled)
-        assertTrue(tool.defaultEnabledValue)
+        assertTrue(tool.isEnabled)
     }
 }
 

--- a/devtools/common/src/iosMain/kotlin/com/maximbircu/devtools/common/stores/PreferencesToolStoreImpl.kt
+++ b/devtools/common/src/iosMain/kotlin/com/maximbircu/devtools/common/stores/PreferencesToolStoreImpl.kt
@@ -13,17 +13,13 @@ actual open class PreferencesToolStoreImpl<T : Any> actual constructor(
         set(value) { nsUserDefaults.setBool(value, "${tool.key}_enabled") }
         get() = nsUserDefaults.getOrDefault(
             "${tool.key}_enabled",
-            tool.defaultEnabledValue,
+            tool.isEnabled,
             nsUserDefaults::boolForKey
         )
 
-    override fun store(value: T) {
-        nsUserDefaults.set(value, tool.key)
-    }
-
-    override fun restore(): T {
-        return nsUserDefaults.get(tool.key, tool.getDefaultValue())
-    }
+    override var value: T
+        get() = nsUserDefaults.get(tool.key, tool.getDefaultValue())
+        set(value) { nsUserDefaults.set(value, tool.key) }
 }
 
 private fun <T : Any> NSUserDefaults.get(key: String, defaultValue: T): T {

--- a/samples/android/src/main/assets/dev-tools.yml
+++ b/samples/android/src/main/assets/dev-tools.yml
@@ -6,7 +6,7 @@ yml-toggle-tool: !toggle {
   title: "Toggle tool",
   description: "A boolean configuration value tool",
   canBeDisabled: true,
-  defaultEnabledValue: false
+  isEnabled: false
 }
 
 ##############################
@@ -17,7 +17,7 @@ yml-text-tool: !text {
   title: "Text tool (String)",
   description: "A text configuration value tool",
   canBeDisabled: true,
-  defaultEnabledValue: false,
+  isEnabled: false,
   defaultValue: "Here can go any text value",
   hint: "String config value"
 }
@@ -30,7 +30,7 @@ yml-text-tool-integer: !text {
   title: "Text tool (Integer)",
   description: "An integer number configuration value tool",
   canBeDisabled: true,
-  defaultEnabledValue: false,
+  isEnabled: false,
   defaultValue: 3,
   hint: "Integer number config value"
 }
@@ -43,7 +43,7 @@ yml-text-tool-floating-point: !text {
   title: "Text tool (Floating point)",
   description: "A floating-point number configuration value tool",
   canBeDisabled: true,
-  defaultEnabledValue: false,
+  isEnabled: false,
   defaultValue: 3.4,
   hint: "Floating point number config value"
 }
@@ -56,7 +56,7 @@ yml-time-tool: !time {
   title: "Time tool",
   description: "A time configuration value tool",
   canBeDisabled: true,
-  defaultEnabledValue: false,
+  isEnabled: false,
   days: 1,
   hours: 2,
   minutes: 3,
@@ -72,7 +72,7 @@ yml-enum-tool: !enum {
   title: "Enum tool",
   description: "An enum configuration value tool",
   canBeDisabled: true,
-  defaultEnabledValue: false,
+  isEnabled: false,
   allowCustom: true,
   defaultValueKey: first-option,
   options: {
@@ -86,7 +86,7 @@ yml-enum-custom-options-provider-tool: !enum {
   title: "Enum tool [Custom Provider]",
   description: "An enum configuration value tool with a custom options provider",
   canBeDisabled: true,
-  defaultEnabledValue: false,
+  isEnabled: false,
   allowCustom: true,
   defaultValueKey: first-option,
   optionsProvider: !!com.maximbircu.devtools.CustomEnumOptionsProvider {
@@ -105,13 +105,13 @@ yml-tools-group: !group {
       title: "Toggle tool",
       description: "A boolean configuration value tool",
       canBeDisabled: true,
-      defaultEnabledValue: false
+      isEnabled: false
     },
     yml-text-tool: !text {
       title: "Text tool (String)",
       description: "A text configuration value tool",
       canBeDisabled: true,
-      defaultEnabledValue: false,
+      isEnabled: false,
       defaultValue: "Here can go any text value",
       hint: "String config value"
     },
@@ -119,7 +119,7 @@ yml-tools-group: !group {
       title: "Time tool",
       description: "A time configuration value tool",
       canBeDisabled: true,
-      defaultEnabledValue: false,
+      isEnabled: false,
       days: 1,
       hours: 2,
       minutes: 3,
@@ -130,7 +130,7 @@ yml-tools-group: !group {
       title: "Enum tool",
       description: "An enum configuration value tool",
       canBeDisabled: true,
-      defaultEnabledValue: false,
+      isEnabled: false,
       allowCustom: true,
       defaultValueKey: first-option,
       options: {

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/CombinedSourcesConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/CombinedSourcesConfigActivity.kt
@@ -45,7 +45,7 @@ class CombinedSourcesConfigActivity : AppCompatActivity() {
                 title = "Toggle tool"
                 description = "A boolean configuration value dev tool"
                 canBeDisabled = true
-                defaultEnabledValue = false
+                isEnabled = false
             },
 
             "memory-text-tool" to TextTool(
@@ -55,7 +55,7 @@ class CombinedSourcesConfigActivity : AppCompatActivity() {
                 title = "Text tool (String)"
                 description = "A text configuration value tool"
                 canBeDisabled = true
-                defaultEnabledValue = false
+                isEnabled = false
             },
             "memory-text-tool-integer" to TextTool(
                 defaultValue = 3,
@@ -64,7 +64,7 @@ class CombinedSourcesConfigActivity : AppCompatActivity() {
                 title = "Text tool (Integer)"
                 description = "An integer number configuration value tool"
                 canBeDisabled = true
-                defaultEnabledValue = false
+                isEnabled = false
             },
             "memory-text-tool-float" to TextTool(
                 defaultValue = 3.4f,
@@ -73,7 +73,7 @@ class CombinedSourcesConfigActivity : AppCompatActivity() {
                 title = "Text tool (Floating point)"
                 description = "A floating-point number configuration value tool"
                 canBeDisabled = true
-                defaultEnabledValue = false
+                isEnabled = false
             }
         )
     }

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/MemorySourceConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/MemorySourceConfigActivity.kt
@@ -47,7 +47,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 title = "Toggle tool"
                 description = "A boolean configuration value dev tool"
                 canBeDisabled = true
-                defaultEnabledValue = false
+                isEnabled = false
             },
 
             "memory-text-tool" to TextTool(
@@ -57,7 +57,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 title = "Text tool (String)"
                 description = "A text configuration value tool"
                 canBeDisabled = true
-                defaultEnabledValue = false
+                isEnabled = false
             },
             "memory-text-tool-integer" to TextTool(
                 defaultValue = 3,
@@ -66,7 +66,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 title = "Text tool (Integer)"
                 description = "An integer number configuration value tool"
                 canBeDisabled = true
-                defaultEnabledValue = false
+                isEnabled = false
             },
             "memory-text-tool-float" to TextTool(
                 defaultValue = 3.4f,
@@ -75,7 +75,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 title = "Text tool (Floating point)"
                 description = "A floating-point number configuration value tool"
                 canBeDisabled = true
-                defaultEnabledValue = false
+                isEnabled = false
             },
 
             "memory-time-tool" to TimeTool(
@@ -88,7 +88,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 title = "Time tool"
                 description = "A time configuration value tool"
                 canBeDisabled = true
-                defaultEnabledValue = false
+                isEnabled = false
             },
 
             "memory-enum-tool" to EnumTool(
@@ -105,7 +105,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 title = "Enum tool"
                 description = "An enum configuration value tool"
                 canBeDisabled = true
-                defaultEnabledValue = false
+                isEnabled = false
             },
             "memory-enum-custom-options-provider-tool" to EnumTool(
                 defaultValueKey = "first-option",
@@ -117,7 +117,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 title = "Enum tool [Custom Provider]"
                 description = "An enum configuration value tool with a custom options provider"
                 canBeDisabled = true
-                defaultEnabledValue = false
+                isEnabled = false
             },
 
             "memory-tools-group" to GroupTool(
@@ -126,7 +126,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                         title = "Toggle tool"
                         description = "A boolean configuration value dev tool"
                         canBeDisabled = true
-                        defaultEnabledValue = false
+                        isEnabled = false
                     },
                     "memory-text-tool" to TextTool(
                         defaultValue = "Here can go any text value",
@@ -135,7 +135,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                         title = "Text tool (String)"
                         description = "A text configuration value tool"
                         canBeDisabled = true
-                        defaultEnabledValue = false
+                        isEnabled = false
                     },
                     "memory-time-tool" to TimeTool(
                         days = 1,
@@ -147,7 +147,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                         title = "Time tool"
                         description = "A time configuration value tool"
                         canBeDisabled = true
-                        defaultEnabledValue = false
+                        isEnabled = false
                     },
                     "memory-enum-tool" to EnumTool(
                         defaultValueKey = "first-option",
@@ -163,7 +163,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                         title = "Enum tool"
                         description = "An enum configuration value tool"
                         canBeDisabled = true
-                        defaultEnabledValue = false
+                        isEnabled = false
                     }
                 )
             ).apply {


### PR DESCRIPTION
Closes: #33

- [x] Unit tests  <!-- Check this if you covered your code with unit tests -->
- [x] Changelog <!-- Check this if you updated the changelog file  -->
- [x] Documentation (Readme) <!-- Check this if you updated the  documentation  -->

### What has been done
1. Add an in-memory persistence mechanism, this way we always store all-new configuration value updates in memory so that the change is not missed as soon as the view is recycled;
2. Cover some more components with unit tests;
3. Fix the time dev tool click ripple.

### How to test
1. Open the app;
2. Select any source;
3. Update configuration value of the first tool;
4. Scroll the list till the end;
5. Scroll the list back to the tool you've updated;
6. Make sure the changes are preserved.