### PR TITLE
Add ability to monitor specific dev tools update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog
 =========
 
 ## Version 1.0.0 *(In development)*
+Issue: [#38](https://github.com/maximbircu/devtools-library/issues/38)
+- Add a critical update flag to each dev tool
+- Do not invoke update config update in case none of the tools was updated
+
 Issue: [#14](https://github.com/maximbircu/devtools-library/issues/14)
 - Set up iOS library module
 - Set up iOS sample app module

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tool/DevToolHelpDialog.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tool/DevToolHelpDialog.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.maximbircu.devtools.android.R
 import com.maximbircu.devtools.android.extensions.hide
+import com.maximbircu.devtools.android.extensions.show
 import com.maximbircu.devtools.common.core.DevTool
 import com.maximbircu.devtools.common.presentation.tool.help.DevToolHelpDialogPresenter
 import com.maximbircu.devtools.common.presentation.tool.help.DevToolHelpDialogView
+import kotlinx.android.synthetic.main.layout_dev_tool_help_dialog.criticalUpdate
 import kotlinx.android.synthetic.main.layout_dev_tool_help_dialog.currentValue
 import kotlinx.android.synthetic.main.layout_dev_tool_help_dialog.defaultValue
 import kotlinx.android.synthetic.main.layout_dev_tool_help_dialog.description
@@ -46,5 +48,13 @@ class DevToolHelpDialog(
 
     override fun setDefaultConfigValue(defaultConfigValue: String) {
         dialog.defaultValue.value = defaultConfigValue
+    }
+
+    override fun showCriticalUpdateLabel() {
+        dialog.criticalUpdate.show()
+    }
+
+    override fun hideCriticalUpdateLabel() {
+        dialog.criticalUpdate.hide()
     }
 }

--- a/devtools/android/src/main/res/layout/layout_dev_tool_help_dialog.xml
+++ b/devtools/android/src/main/res/layout/layout_dev_tool_help_dialog.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:theme="@style/Theme.DevTools"
     >
     <LinearLayout
         android:layout_width="match_parent"
@@ -40,6 +41,23 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:title="@string/dev_tool_help_dialog_default_value"
+            />
+
+        <TextView
+            android:id="@+id/criticalUpdate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="16dp"
+            android:drawableStart="@android:drawable/stat_sys_warning"
+            android:drawableLeft="@android:drawable/stat_sys_warning"
+            android:drawablePadding="4dp"
+            android:drawableTint="?android:textColorPrimary"
+            android:gravity="bottom"
+            android:text="@string/dev_tool_help_dialog_critical_update"
+            android:textAppearance="?attr/textAppearanceBody2"
+            android:textStyle="bold"
+            tools:targetApi="m"
             />
     </LinearLayout>
 </ScrollView>

--- a/devtools/android/src/main/res/values/strings.xml
+++ b/devtools/android/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="dev_tool_help_dialog_key">Key</string>
     <string name="dev_tool_help_dialog_current_value">Current value</string>
     <string name="dev_tool_help_dialog_default_value">Default value</string>
+    <string name="dev_tool_help_dialog_critical_update">Triggers a critical update!</string>
 
     <!-- Group Tool Context Menu -->
     <string name="group_tool_context_menu_enable_all">Enable all</string>

--- a/devtools/common/build.gradle
+++ b/devtools/common/build.gradle
@@ -101,7 +101,7 @@ kotlin {
             if(taskName.toLowerCase().contains("ios") && taskName.toLowerCase().contains("test")) {
                 task.setEnabled(false)
             }
-            if (taskName.contains("assembleRelease")) {
+            if (taskName.contains("assemble")) {
                 task.dependsOn "releaseFatFramework"
             }
         }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
@@ -11,7 +11,7 @@ interface DevTools : DevToolsStorage {
 
     /**
      * This function is invoked whenever a dev tool state is updated.
-     * isCriticalUpdate will be true in case at least one updated tool will be critical.
+     * isCriticalUpdate will be true in the case at least one updated tool will be critical.
      * @see [com.maximbircu.devtools.common.core.DevTool.isCritical]
      */
     var onConfigUpdated: (isCriticalUpdate: Boolean) -> Unit

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
@@ -16,9 +16,16 @@ abstract class DevTool<T : Any>(
     var title: String? = null,
     var description: String = "",
     var canBeDisabled: Boolean = false,
-    var defaultEnabledValue: Boolean = true
+    var defaultEnabledValue: Boolean = true,
+    var isCritical: Boolean = false
 ) {
     private var _key: String? = null
+
+    /**
+     * This property will be true in case the in memory tool state will be different from the
+     * persisted one.
+     */
+    val hasUnsavedChanges: Boolean get() = value != store.value || isEnabled != store.isEnabled
 
     /**
      * A unique dev tool identifier.

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
@@ -23,7 +23,7 @@ abstract class DevTool<T : Any>(
     private var _key: String? = null
 
     /**
-     * This property will be true in case the in memory tool state will be different from the
+     * This property will be true in case the in-memory tool state will be different from the
      * persisted one.
      */
     val hasUnsavedChanges: Boolean get() = value != store.value || isEnabled != store.isEnabled

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
@@ -11,6 +11,7 @@ import com.maximbircu.devtools.common.stores.PreferencesToolStoreImpl
  * @property description short description of the dev tool configuration value
  * @property canBeDisabled the user can enable/disable the tool if true
  * @property defaultEnabledValue true if the tool is enabled and false vice-versa
+ * @property isCritical true if the tool should trigger a critical update and false vice-versa
  */
 abstract class DevTool<T : Any>(
     var title: String? = null,

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/help/DevToolHelpDialogPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/help/DevToolHelpDialogPresenter.kt
@@ -34,10 +34,11 @@ private class DevToolHelpDialogPresenterImpl(
     view: DevToolHelpDialogView
 ) : BasePresenter<DevToolHelpDialogView>(view), DevToolHelpDialogPresenter {
     override fun onToolBind(tool: DevTool<*>) {
-        view.bindDescription(tool.description)
         view.setKey(tool.key)
         view.setCurrentConfigValue(tool.value.toString())
         view.setDefaultConfigValue(tool.getDefaultValue().toString())
+        view.bindDescription(tool.description)
+        view.bindCriticalUpdateInfo(tool.isCritical)
     }
 
     private fun DevToolHelpDialogView.bindDescription(description: String) {
@@ -45,6 +46,14 @@ private class DevToolHelpDialogPresenterImpl(
             setDescription(description)
         } else {
             hideDescription()
+        }
+    }
+
+    private fun DevToolHelpDialogView.bindCriticalUpdateInfo(isCriticalUpdate: Boolean) {
+        if (isCriticalUpdate) {
+            showCriticalUpdateLabel()
+        } else {
+            hideCriticalUpdateLabel()
         }
     }
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/help/DevToolHelpDialogView.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/help/DevToolHelpDialogView.kt
@@ -44,4 +44,16 @@ interface DevToolHelpDialogView : BaseView {
      * @see [com.maximbircu.devtools.common.core.DevTool.getDefaultValue]
      */
     fun setDefaultConfigValue(defaultConfigValue: String)
+
+    /**
+     * Should show a warning label that will notify the user that the dev tool will trigger a
+     * critical update.
+     */
+    fun showCriticalUpdateLabel()
+
+    /**
+     * Should hide the warning label that notifies the user that the dev tool will trigger a
+     * critical update because the tool is not critical.
+     */
+    fun hideCriticalUpdateLabel()
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaToolFactory.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaToolFactory.kt
@@ -16,6 +16,7 @@ internal abstract class JsonSchemaToolFactory<T : DevTool<*>>(
         description = jsonObject["description"]?.content ?: ""
         canBeDisabled = jsonObject["canBeDisabled"]?.boolean ?: true
         defaultEnabledValue = jsonObject["defaultEnabledValue"]?.boolean ?: false
+        isCritical = jsonObject["isCritical"]?.boolean ?: true
     }
 
     protected abstract fun createDevTool(): T

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
@@ -1,9 +1,10 @@
 package com.maximbircu.devtools.common
 
 import com.maximbircu.devtools.common.core.createTool
-import com.maximbircu.devtools.common.extensions.forEachRecursively
 import com.maximbircu.devtools.common.mvp.BaseTest
 import com.maximbircu.devtools.common.presentation.tools.group.GroupTool
+import com.maximbircu.devtools.common.presentation.tools.text.TextTool
+import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
 import com.maximbircu.devtools.common.readers.DevToolsSources
 import com.maximbircu.devtools.common.readers.memory
 import com.maximbircu.devtools.common.utils.mockk
@@ -13,30 +14,59 @@ import kotlin.test.Test
 
 class DevToolsImplTest : BaseTest() {
     @Test
-    fun `persists tools state`() {
+    fun `persists tool state in case it has unsaved changes`() {
+        val childTools = mapOf(
+            "first-child-tool" to createTool<ToggleTool>(),
+            "second-child-tool" to createTool<TextTool> { ::hasUnsavedChanges returns true }
+        )
         val tools = mapOf(
-            "first-tool" to createTool(),
-            "second-tool" to createTool<GroupTool> {
-                ::tools returns mapOf("child-tool" to createTool())
-            }
+            "first-tool" to createTool { ::hasUnsavedChanges returns true },
+            "second-tool" to createTool<GroupTool> { ::tools returns childTools }
         )
         val devTools = DevTools.create(DevToolsSources.memory(tools))
 
         devTools.persistToolsState()
 
-        tools.forEachRecursively { _, tool -> verify { tool.persistState() } }
+        verify { tools.getValue("first-tool").persistState() }
+        verify { childTools.getValue("second-child-tool").persistState() }
     }
 
     @Test
-    fun `notifies listeners about dev tools configuration update`() {
-        val onConfigUpdate: () -> Unit = mockk(relaxed = true)
+    fun `notifies the listener about tools config update if at least one tool was updated`() {
+        val onConfigUpdate: (Boolean) -> Unit = mockk(relaxed = true)
         val devTools = DevTools.create(
-            DevToolsSources.memory(emptyMap()),
+            DevToolsSources.memory(
+                mapOf(
+                    "first-tool" to createTool { ::hasUnsavedChanges returns true },
+                    "second-tool" to createTool()
+                )
+            ),
             onConfigUpdate = onConfigUpdate
         )
 
         devTools.persistToolsState()
 
-        verify { onConfigUpdate() }
+        verify { onConfigUpdate(false) }
+    }
+
+    @Test
+    fun `notifies the listener about tools critical config update if at least one happened`() {
+        val onConfigUpdate: (Boolean) -> Unit = mockk(relaxed = true)
+        val devTools = DevTools.create(
+            DevToolsSources.memory(
+                mapOf(
+                    "first-tool" to createTool {
+                        ::hasUnsavedChanges returns true
+                        ::isCritical returns true
+                    },
+                    "second-tool" to createTool()
+                )
+            ),
+            onConfigUpdate = onConfigUpdate
+        )
+
+        devTools.persistToolsState()
+
+        verify { onConfigUpdate(true) }
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
@@ -50,6 +50,19 @@ class DevToolsImplTest : BaseTest() {
     }
 
     @Test
+    fun `doesn't notify the listener about tools critical config update if there are no changes`() {
+        val onConfigUpdate: (Boolean) -> Unit = mockk(relaxed = true)
+        val devTools = DevTools.create(
+            DevToolsSources.memory(mapOf("first-tool" to createTool())),
+            onConfigUpdate = onConfigUpdate
+        )
+
+        devTools.persistToolsState()
+
+        verify(exactly = 0) { onConfigUpdate(any()) }
+    }
+
+    @Test
     fun `notifies the listener about tools critical config update if at least one happened`() {
         val onConfigUpdate: (Boolean) -> Unit = mockk(relaxed = true)
         val devTools = DevTools.create(

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/core/DevToolTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/core/DevToolTest.kt
@@ -52,6 +52,33 @@ class DevToolTest : BaseTest() {
         assertEquals("Default configuration value", devTool.value)
     }
 
+    // region Has unsaved changes
+
+    @Test
+    fun `returns false in case there are no some unsaved changes`() {
+        val devTool = createDevTool()
+        every { store.isEnabled } returns false
+        every { store.value } returns "Configuration value"
+        devTool.key = "some-key"
+
+        assertFalse(devTool.hasUnsavedChanges)
+    }
+
+    @Test
+    fun `returns true in case there are some unsaved changes`() {
+        val devTool = createDevTool()
+        every { store.isEnabled } returns false
+        every { store.value } returns "Configuration value"
+        devTool.key = "some-key"
+
+        devTool.isEnabled = true
+        devTool.value = "New configuration value"
+
+        assertTrue(devTool.hasUnsavedChanges)
+    }
+
+    // endregion
+
     @Test
     fun `throws exception when trying to access tool key if it was not set`() {
         val devTool = createDevTool()

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/core/DevToolTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/core/DevToolTest.kt
@@ -55,7 +55,7 @@ class DevToolTest : BaseTest() {
     // region Has unsaved changes
 
     @Test
-    fun `returns false in case there are no some unsaved changes`() {
+    fun `returns false in case there are no unsaved changes`() {
         val devTool = createDevTool()
         every { store.isEnabled } returns false
         every { store.value } returns "Configuration value"
@@ -65,7 +65,32 @@ class DevToolTest : BaseTest() {
     }
 
     @Test
-    fun `returns true in case there are some unsaved changes`() {
+    fun `returns true in case there the config value was changed`() {
+        val devTool = createDevTool()
+        every { store.isEnabled } returns false
+        every { store.value } returns "Configuration value"
+        devTool.key = "some-key"
+
+        devTool.isEnabled = false
+        devTool.value = "New configuration value"
+
+        assertTrue(devTool.hasUnsavedChanges)
+    }
+
+    @Test
+    fun `returns true in case there the tool enable state was changed`() {
+        val devTool = createDevTool()
+        every { store.isEnabled } returns false
+        every { store.value } returns "Configuration value"
+
+        devTool.isEnabled = true
+        devTool.value = "Configuration value"
+
+        assertTrue(devTool.hasUnsavedChanges)
+    }
+
+    @Test
+    fun `returns true in case both config value and tool enable state was changed`() {
         val devTool = createDevTool()
         every { store.isEnabled } returns false
         every { store.value } returns "Configuration value"

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolHelpDialogPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolHelpDialogPresenterImplTest.kt
@@ -10,7 +10,7 @@ import com.maximbircu.devtools.common.utils.returns
 import io.mockk.verify
 import kotlin.test.Test
 
-class DevToolHelpDialogPresenterImpl :
+class DevToolHelpDialogPresenterImplTest :
     BasePresenterTest<DevToolHelpDialogView, DevToolHelpDialogPresenter>(mockk()) {
     override fun createPresenter() = DevToolHelpDialogPresenter.create(view)
 
@@ -65,5 +65,25 @@ class DevToolHelpDialogPresenterImpl :
         presenter.onToolBind(tool)
 
         verify { view.setDefaultConfigValue("Default configuration value") }
+    }
+
+    @Test
+    fun `shows critical update label on tool bind if tool is critical`() {
+        val tool: DevTool<*> = createTool { ::isCritical returns true }
+
+        presenter.onToolBind(tool)
+
+
+        verify { view.showCriticalUpdateLabel() }
+    }
+
+    @Test
+    fun `hides critical update label on tool bind if tool is not critical`() {
+        val tool: DevTool<*> = createTool { ::isCritical returns false }
+
+        presenter.onToolBind(tool)
+
+
+        verify { view.hideCriticalUpdateLabel() }
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolHelpDialogPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolHelpDialogPresenterImplTest.kt
@@ -73,7 +73,6 @@ class DevToolHelpDialogPresenterImplTest :
 
         presenter.onToolBind(tool)
 
-
         verify { view.showCriticalUpdateLabel() }
     }
 
@@ -82,7 +81,6 @@ class DevToolHelpDialogPresenterImplTest :
         val tool: DevTool<*> = createTool { ::isCritical returns false }
 
         presenter.onToolBind(tool)
-
 
         verify { view.hideCriticalUpdateLabel() }
     }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaToolFactoryTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaToolFactoryTest.kt
@@ -17,6 +17,8 @@ class JsonSchemaToolFactoryTest : BaseTest() {
             "description" to "Tool description"
             "canBeDisabled" to false
             "isEnabled" to true
+            "defaultEnabledValue" to true
+            "isCritical" to false
         }
         val factory = JsonSchemaToolFactoryStub(jsonObject)
 
@@ -25,7 +27,8 @@ class JsonSchemaToolFactoryTest : BaseTest() {
         assertEquals("Tool title", tool.title)
         assertEquals("Tool description", tool.description)
         assertFalse(tool.canBeDisabled)
-        assertTrue(tool.isEnabled)
+        assertTrue(tool.defaultEnabledValue)
+        assertFalse(tool.isCritical)
     }
 }
 

--- a/devtools/ios/DevtoolsFramework/DevToolsConfiguration.swift
+++ b/devtools/ios/DevtoolsFramework/DevToolsConfiguration.swift
@@ -7,6 +7,6 @@ public final class DevToolsConfiguration {
 
     private func initSource(devTools: [String: DevTool]) {
         let source = DevToolsSources().memory(devTools: devTools)
-        _ = DevToolsCompanion().create(devToolsSource: KotlinArray(size: 1) { _ in source }) { }
+        _ = DevToolsCompanion().create(devToolsSource: KotlinArray(size: 1) { _ in source }) { _ in }
     }
 }

--- a/devtools/ios/Podfile.lock
+++ b/devtools/ios/Podfile.lock
@@ -5,7 +5,7 @@ DEPENDENCIES:
   - SwiftLint
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - SwiftLint
 
 SPEC CHECKSUMS:
@@ -13,4 +13,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 8365437d46da626bd80249dc73651bc46d8d5cb0
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.9.1

--- a/samples/android/src/main/assets/dev-tools.yml
+++ b/samples/android/src/main/assets/dev-tools.yml
@@ -6,7 +6,8 @@ yml-toggle-tool: !toggle {
   title: "Toggle tool",
   description: "A boolean configuration value tool",
   canBeDisabled: true,
-  defaultEnabledValue: false
+  defaultEnabledValue: false,
+  isCritical: true
 }
 
 ##############################
@@ -18,6 +19,7 @@ yml-text-tool: !text {
   description: "A text configuration value tool",
   canBeDisabled: true,
   defaultEnabledValue: false,
+  isCritical: false,
   defaultValue: "Here can go any text value",
   hint: "String config value"
 }
@@ -31,6 +33,7 @@ yml-text-tool-integer: !text {
   description: "An integer number configuration value tool",
   canBeDisabled: true,
   defaultEnabledValue: false,
+  isCritical: true,
   defaultValue: 3,
   hint: "Integer number config value"
 }
@@ -44,6 +47,7 @@ yml-text-tool-floating-point: !text {
   description: "A floating-point number configuration value tool",
   canBeDisabled: true,
   defaultEnabledValue: false,
+  isCritical: false,
   defaultValue: 3.4,
   hint: "Floating point number config value"
 }
@@ -57,6 +61,7 @@ yml-time-tool: !time {
   description: "A time configuration value tool",
   canBeDisabled: true,
   defaultEnabledValue: false,
+  isCritical: true,
   days: 1,
   hours: 2,
   minutes: 3,
@@ -73,6 +78,7 @@ yml-enum-tool: !enum {
   description: "An enum configuration value tool",
   canBeDisabled: true,
   defaultEnabledValue: false,
+  isCritical: false,
   allowCustom: true,
   defaultValueKey: first-option,
   options: {
@@ -87,6 +93,7 @@ yml-enum-custom-options-provider-tool: !enum {
   description: "An enum configuration value tool with a custom options provider",
   canBeDisabled: true,
   defaultEnabledValue: false,
+  isCritical: true,
   allowCustom: true,
   defaultValueKey: first-option,
   optionsProvider: !!com.maximbircu.devtools.CustomEnumOptionsProvider {
@@ -105,13 +112,15 @@ yml-tools-group: !group {
       title: "Toggle tool",
       description: "A boolean configuration value tool",
       canBeDisabled: true,
-      defaultEnabledValue: false
+      defaultEnabledValue: false,
+      isCritical: false
     },
     yml-text-tool: !text {
       title: "Text tool (String)",
       description: "A text configuration value tool",
       canBeDisabled: true,
       defaultEnabledValue: false,
+      isCritical: true,
       defaultValue: "Here can go any text value",
       hint: "String config value"
     },
@@ -120,6 +129,7 @@ yml-tools-group: !group {
       description: "A time configuration value tool",
       canBeDisabled: true,
       defaultEnabledValue: false,
+      isCritical: false,
       days: 1,
       hours: 2,
       minutes: 3,
@@ -131,6 +141,7 @@ yml-tools-group: !group {
       description: "An enum configuration value tool",
       canBeDisabled: true,
       defaultEnabledValue: false,
+      isCritical: true,
       allowCustom: true,
       defaultValueKey: first-option,
       options: {

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/CombinedSourcesConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/CombinedSourcesConfigActivity.kt
@@ -3,6 +3,8 @@ package com.maximbircu.devtools.configscreens
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.Gravity
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.maximbircu.devtools.R.layout
 import com.maximbircu.devtools.android.DevToolsConfigurationScreen
@@ -16,6 +18,7 @@ import com.maximbircu.devtools.common.readers.json
 import com.maximbircu.devtools.common.readers.memory
 import kotlinx.android.synthetic.main.activity_tools_container.devToolsContainer
 
+@Suppress("LongMethod")
 class CombinedSourcesConfigActivity : AppCompatActivity() {
     private lateinit var devtools: DevTools
 
@@ -33,12 +36,22 @@ class CombinedSourcesConfigActivity : AppCompatActivity() {
         val memorySource = DevToolsSources.memory(getTools())
         val ymlSource = DevToolsSources.yaml(assets, "dev-tools.yml")
         val jsonSource = DevToolsSources.json(assets.open("dev-tools.json").reader().readText())
+
         devtools = DevTools.create(memorySource, ymlSource, jsonSource)
+
+        devtools.onConfigUpdated = { isCriticalUpdate ->
+            val toast = Toast.makeText(
+                this,
+                "A ${if (isCriticalUpdate) "critical" else "non-critical"} updated performed!",
+                Toast.LENGTH_SHORT
+            )
+            toast.setGravity(Gravity.CENTER, 0, 0)
+            toast.show()
+        }
 
         DevToolsConfigurationScreen.attachToView(devToolsContainer, devtools)
     }
 
-    @Suppress("LongMethod", "ComplexMethod")
     private fun getTools(): Map<String, DevTool<*>> {
         return mapOf(
             "memory-toggle-tool" to ToggleTool(defaultValue = false).apply {

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/JsonSchemaSourceConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/JsonSchemaSourceConfigActivity.kt
@@ -3,6 +3,8 @@ package com.maximbircu.devtools.configscreens
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.Gravity
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.maximbircu.devtools.R.layout
 import com.maximbircu.devtools.android.DevToolsConfigurationScreen
@@ -11,6 +13,7 @@ import com.maximbircu.devtools.common.readers.DevToolsSources
 import com.maximbircu.devtools.common.readers.json
 import kotlinx.android.synthetic.main.activity_tools_container.devToolsContainer
 
+@Suppress("LongMethod")
 class JsonSchemaSourceConfigActivity : AppCompatActivity() {
     private lateinit var devtools: DevTools
 
@@ -27,6 +30,16 @@ class JsonSchemaSourceConfigActivity : AppCompatActivity() {
 
         val source = DevToolsSources.json(assets.open("dev-tools.json").reader().readText())
         devtools = DevTools.create(source)
+
+        devtools.onConfigUpdated = { isCriticalUpdate ->
+            val toast = Toast.makeText(
+                this,
+                "A ${if (isCriticalUpdate) "critical" else "non-critical"} updated performed!",
+                Toast.LENGTH_SHORT
+            )
+            toast.setGravity(Gravity.CENTER, 0, 0)
+            toast.show()
+        }
 
         DevToolsConfigurationScreen.attachToView(devToolsContainer, devtools)
     }

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/MemorySourceConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/MemorySourceConfigActivity.kt
@@ -3,6 +3,8 @@ package com.maximbircu.devtools.configscreens
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.Gravity
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.maximbircu.devtools.CustomEnumOptionsProvider
 import com.maximbircu.devtools.R.layout
@@ -19,7 +21,7 @@ import com.maximbircu.devtools.common.readers.DevToolsSources
 import com.maximbircu.devtools.common.readers.memory
 import kotlinx.android.synthetic.main.activity_tools_container.devToolsContainer
 
-@Suppress("LargeClass")
+@Suppress("LongMethod", "ComplexMethod", "LargeClass")
 class MemorySourceConfigActivity : AppCompatActivity() {
     private lateinit var devtools: DevTools
 
@@ -36,11 +38,19 @@ class MemorySourceConfigActivity : AppCompatActivity() {
 
         val source = DevToolsSources.memory(getTools())
         devtools = DevTools.create(source)
+        devtools.onConfigUpdated = { isCriticalUpdate ->
+            val toast = Toast.makeText(
+                this,
+                "A ${if (isCriticalUpdate) "critical" else "non-critical"} updated performed!",
+                Toast.LENGTH_SHORT
+            )
+            toast.setGravity(Gravity.CENTER, 0, 0)
+            toast.show()
+        }
 
         DevToolsConfigurationScreen.attachToView(devToolsContainer, devtools)
     }
 
-    @Suppress("LongMethod", "ComplexMethod")
     private fun getTools(): Map<String, DevTool<*>> {
         return mapOf(
             "memory-toggle-tool" to ToggleTool(defaultValue = false).apply {
@@ -48,6 +58,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 description = "A boolean configuration value dev tool"
                 canBeDisabled = true
                 defaultEnabledValue = false
+                isCritical = true
             },
 
             "memory-text-tool" to TextTool(
@@ -58,6 +69,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 description = "A text configuration value tool"
                 canBeDisabled = true
                 defaultEnabledValue = false
+                isCritical = false
             },
             "memory-text-tool-integer" to TextTool(
                 defaultValue = 3,
@@ -67,6 +79,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 description = "An integer number configuration value tool"
                 canBeDisabled = true
                 defaultEnabledValue = false
+                isCritical = true
             },
             "memory-text-tool-float" to TextTool(
                 defaultValue = 3.4f,
@@ -76,6 +89,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 description = "A floating-point number configuration value tool"
                 canBeDisabled = true
                 defaultEnabledValue = false
+                isCritical = false
             },
 
             "memory-time-tool" to TimeTool(
@@ -89,6 +103,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 description = "A time configuration value tool"
                 canBeDisabled = true
                 defaultEnabledValue = false
+                isCritical = true
             },
 
             "memory-enum-tool" to EnumTool(
@@ -106,6 +121,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 description = "An enum configuration value tool"
                 canBeDisabled = true
                 defaultEnabledValue = false
+                isCritical = false
             },
             "memory-enum-custom-options-provider-tool" to EnumTool(
                 defaultValueKey = "first-option",
@@ -118,6 +134,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 description = "An enum configuration value tool with a custom options provider"
                 canBeDisabled = true
                 defaultEnabledValue = false
+                isCritical = true
             },
 
             "memory-tools-group" to GroupTool(
@@ -127,6 +144,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                         description = "A boolean configuration value dev tool"
                         canBeDisabled = true
                         defaultEnabledValue = false
+                        isCritical = false
                     },
                     "memory-text-tool" to TextTool(
                         defaultValue = "Here can go any text value",
@@ -136,6 +154,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                         description = "A text configuration value tool"
                         canBeDisabled = true
                         defaultEnabledValue = false
+                        isCritical = true
                     },
                     "memory-time-tool" to TimeTool(
                         days = 1,
@@ -148,6 +167,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                         description = "A time configuration value tool"
                         canBeDisabled = true
                         defaultEnabledValue = false
+                        isCritical = false
                     },
                     "memory-enum-tool" to EnumTool(
                         defaultValueKey = "first-option",
@@ -164,6 +184,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                         description = "An enum configuration value tool"
                         canBeDisabled = true
                         defaultEnabledValue = false
+                        isCritical = true
                     }
                 )
             ).apply {

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/YamlSourceConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/YamlSourceConfigActivity.kt
@@ -3,6 +3,8 @@ package com.maximbircu.devtools.configscreens
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.Gravity
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.maximbircu.devtools.R.layout
 import com.maximbircu.devtools.android.DevToolsConfigurationScreen
@@ -11,6 +13,7 @@ import com.maximbircu.devtools.common.DevTools
 import com.maximbircu.devtools.common.readers.DevToolsSources
 import kotlinx.android.synthetic.main.activity_tools_container.devToolsContainer
 
+@Suppress("LongMethod")
 class YamlSourceConfigActivity : AppCompatActivity() {
     private lateinit var devtools: DevTools
 
@@ -27,6 +30,16 @@ class YamlSourceConfigActivity : AppCompatActivity() {
 
         val source = DevToolsSources.yaml(assets, "dev-tools.yml")
         devtools = DevTools.create(source)
+
+        devtools.onConfigUpdated = { isCriticalUpdate ->
+            val toast = Toast.makeText(
+                this,
+                "A ${if (isCriticalUpdate) "critical" else "non-critical"} updated performed!",
+                Toast.LENGTH_SHORT
+            )
+            toast.setGravity(Gravity.CENTER, 0, 0)
+            toast.show()
+        }
 
         DevToolsConfigurationScreen.attachToView(devToolsContainer, devtools)
     }


### PR DESCRIPTION
Closes: #38 

- [x] Unit tests  <!-- Check this if you covered your code with unit tests -->
- [x] Changelog <!-- Check this if you updated the changelog file  -->
- [x] Documentation (Readme) <!-- Check this if you updated the  documentation  -->

### What has been done
1. Add a critical update flag to each dev tool
1. Do not invoke update config update in case none of the tools was updated

### Screenshots
Android critical update | Android non-ciritical update | Android Help Dialog  | iOS
:-: | :-: | :-: | :-:
![image](https://user-images.githubusercontent.com/12527390/80312867-5f5c3280-87f0-11ea-9f9f-c92e916349d1.png)|![image](https://user-images.githubusercontent.com/12527390/80312889-7bf86a80-87f0-11ea-9b3e-a2a65b857404.png)|![image](https://user-images.githubusercontent.com/12527390/80312904-887cc300-87f0-11ea-967f-1b8cd3d4231a.png)| iOS implementation will be added later|


### How to test
Usecase 1
1. Open the sample app
2. Update any critical tool (You can find the critical tool using the help dialog)
3. Make sure you see a toast telling that a critical update just happened 

Usecase 2
1. Open the sample app
2. Update any non-critical tool (You can find a non-critical tool using the help dialog)
3. Make sure you see a toast telling that a non-critical update just happened 