### PR TITLE
Add ability to get all config as json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog
 =========
 
 ## Version 1.0.0 *(In development)*
+Issue: [#37](https://github.com/maximbircu/devtools-library/issues/37)
+- Add DevToolsStorage#getAllConfigAsJson method, which takes a filter parameter and returns a filtered JSON string of configuration values
+
 Issue: [#38](https://github.com/maximbircu/devtools-library/issues/38)
 - Add a critical update flag to each dev tool
 - Do not invoke update config update in case none of the tools was updated

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevToolsStorage.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevToolsStorage.kt
@@ -1,6 +1,7 @@
 package com.maximbircu.devtools.common
 
 import com.maximbircu.devtools.common.core.DevTool
+import com.maximbircu.devtools.common.extensions.toJsonObjectOfValues
 import com.maximbircu.devtools.common.presentation.tools.group.GroupTool
 
 /**
@@ -19,6 +20,14 @@ interface DevToolsStorage {
      * @return [T] configuration value of the dev tool with [key]
      */
     fun <T> getValue(key: String): T
+
+    /**
+     * Provides all configuration values as JSON string.
+     *
+     * @param filter (predicate) will be invoked for each [DevTool] to decide whether to add
+     * the config to the final JSON object result or not.
+     */
+    fun getAllConfigAsJson(filter: (tool: DevTool<*>) -> Boolean = { true }): String
 
     /**
      * Provides a [DevToolsStorage] which contains all group member tools.
@@ -48,6 +57,10 @@ class DevToolsStorageImpl(
 
     override fun getGroup(key: String): DevToolsStorage {
         return DevToolsStorageImpl((getDevTool(key) as GroupTool).tools)
+    }
+
+    override fun getAllConfigAsJson(filter: (tool: DevTool<*>) -> Boolean): String {
+        return tools.toJsonObjectOfValues(filter).toString()
     }
 
     private fun getDevTool(key: String): DevTool<*> {

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/extensions/DevToolExtensions.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/extensions/DevToolExtensions.kt
@@ -2,6 +2,9 @@ package com.maximbircu.devtools.common.extensions
 
 import com.maximbircu.devtools.common.core.DevTool
 import com.maximbircu.devtools.common.presentation.tools.group.GroupTool
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 
 internal fun Map<String, DevTool<*>>.forEachRecursively(action: (String, DevTool<*>) -> Unit) {
     forEach { (key, tool) ->
@@ -10,4 +13,31 @@ internal fun Map<String, DevTool<*>>.forEachRecursively(action: (String, DevTool
         }
         action(key, tool)
     }
+}
+
+@Suppress("LongMethod")
+internal fun Map<String, DevTool<*>>.toJsonObjectOfValues(
+    predicate: (tool: DevTool<*>) -> Boolean = { true }
+): JsonObject {
+    val configValues = mutableMapOf<String, JsonElement>()
+    forEach { (key, tool) ->
+        if (tool is GroupTool) {
+            val childToolsValues = tool.tools.toJsonObjectOfValues(predicate)
+            if (childToolsValues.isNotEmpty()) {
+                configValues[key] = childToolsValues
+            }
+        } else {
+            if (predicate(tool)) {
+                configValues[key] = tool.value.toJsonPrimitive()
+            }
+        }
+    }
+    return JsonObject(configValues)
+}
+
+private fun Any.toJsonPrimitive(): JsonPrimitive = when (this) {
+    is String -> JsonPrimitive(this)
+    is Boolean -> JsonPrimitive(this)
+    is Number -> JsonPrimitive(this)
+    else -> throw IllegalArgumentException("$this not supported!")
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsStorageImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsStorageImplTest.kt
@@ -59,6 +59,31 @@ class DevToolsStorageImplTest : BaseTest() {
     }
 
     @Test
+    fun `returns proper JSON config`() {
+        val tools = mapOf<String, DevTool<*>>(
+            "first-tool" to createTool<ToggleTool> { ::value returns true },
+            "second-tool" to GroupTool(
+                mapOf(
+                    "first-child-tool" to createTool<TextTool> { ::value returns "First value" },
+                    "second-child-tool" to createTool<TextTool> { ::value returns "Second value" }
+                )
+            )
+        )
+        val expectedConfigJsonString = json {
+            "first-tool" to true
+            "second-tool" to json {
+                "first-child-tool" to "First value"
+                "second-child-tool" to "Second value"
+            }
+        }.toString()
+        val storage: DevToolsStorage = DevToolsStorageImpl(tools)
+
+        val configJsonString = storage.getAllConfigAsJson()
+
+        assertEquals(expectedConfigJsonString, configJsonString)
+    }
+
+    @Test
     fun `returns proper filtered JSON config`() {
         val tools = mapOf<String, DevTool<*>>(
             "first-tool" to createTool<ToggleTool> {
@@ -86,6 +111,10 @@ class DevToolsStorageImplTest : BaseTest() {
                     "second-child-tool" to createTool<TextTool> {
                         ::value returns "Second value"
                         ::isEnabled returns true
+                    },
+                    "third-child-tool" to createTool<TextTool> {
+                        ::value returns 3.4
+                        ::isEnabled returns true
                     }
                 )
             )
@@ -94,9 +123,9 @@ class DevToolsStorageImplTest : BaseTest() {
             "first-tool" to true
             "third-tool" to json {
                 "second-child-tool" to "Second value"
+                "third-child-tool" to 3.4
             }
         }.toString()
-
         val storage: DevToolsStorage = DevToolsStorageImpl(tools)
 
         val configJsonString = storage.getAllConfigAsJson { it.isEnabled }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/extensions/DevToolExtensionsKtTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/extensions/DevToolExtensionsKtTest.kt
@@ -6,8 +6,10 @@ import com.maximbircu.devtools.common.presentation.tools.group.GroupTool
 import com.maximbircu.devtools.common.presentation.tools.text.TextTool
 import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
 import com.maximbircu.devtools.common.utils.mockk
+import com.maximbircu.devtools.common.utils.returns
 import io.mockk.verify
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 
 class DevToolExtensionsKtTest {
     @Test
@@ -21,5 +23,13 @@ class DevToolExtensionsKtTest {
         verify { listener("first-tool", tools.getValue("first-tool")) }
         verify { listener("second-tool", groupTool) }
         verify { listener("child-tool", groupTool.tools.getValue("child-tool")) }
+    }
+
+    @Test
+    fun `throws exception when tries to convert to primitive json element a non primitive type`() {
+        val tools = mapOf<String, DevTool<*>>(
+            "first-tool" to createTool<ToggleTool> { ::value returns object {} }
+        )
+        assertFailsWith<IllegalArgumentException> { tools.toJsonObjectOfValues() }
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/extensions/DevToolExtensionsKtTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/extensions/DevToolExtensionsKtTest.kt
@@ -8,7 +8,9 @@ import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
 import com.maximbircu.devtools.common.utils.mockk
 import com.maximbircu.devtools.common.utils.returns
 import io.mockk.verify
+import kotlinx.serialization.json.json
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class DevToolExtensionsKtTest {
@@ -23,6 +25,79 @@ class DevToolExtensionsKtTest {
         verify { listener("first-tool", tools.getValue("first-tool")) }
         verify { listener("second-tool", groupTool) }
         verify { listener("child-tool", groupTool.tools.getValue("child-tool")) }
+    }
+
+    @Test
+    fun `returns proper JSON config`() {
+        val tools = mapOf<String, DevTool<*>>(
+            "first-tool" to createTool<ToggleTool> { ::value returns true },
+            "second-tool" to GroupTool(
+                mapOf(
+                    "first-child-tool" to createTool<TextTool> { ::value returns "First value" },
+                    "second-child-tool" to createTool<TextTool> { ::value returns "Second value" }
+                )
+            )
+        )
+        val expectedConfigJsonObject = json {
+            "first-tool" to true
+            "second-tool" to json {
+                "first-child-tool" to "First value"
+                "second-child-tool" to "Second value"
+            }
+        }
+
+        val configJsonObject = tools.toJsonObjectOfValues()
+
+        assertEquals(expectedConfigJsonObject, configJsonObject)
+    }
+
+    @Test
+    fun `returns proper filtered JSON config`() {
+        val tools = mapOf<String, DevTool<*>>(
+            "first-tool" to createTool<ToggleTool> {
+                ::value returns true
+                ::isEnabled returns true
+            },
+            "second-tool" to GroupTool(
+                mapOf(
+                    "first-child-tool" to createTool<TextTool> {
+                        ::value returns "First value"
+                        ::isEnabled returns false
+                    },
+                    "second-child-tool" to createTool<TextTool> {
+                        ::value returns "Second value"
+                        ::isEnabled returns false
+                    }
+                )
+            ),
+            "third-tool" to GroupTool(
+                mapOf(
+                    "first-child-tool" to createTool<TextTool> {
+                        ::value returns "First value"
+                        ::isEnabled returns false
+                    },
+                    "second-child-tool" to createTool<TextTool> {
+                        ::value returns "Second value"
+                        ::isEnabled returns true
+                    },
+                    "third-child-tool" to createTool<TextTool> {
+                        ::value returns 3.4
+                        ::isEnabled returns true
+                    }
+                )
+            )
+        )
+        val expectedConfigJsonObject = json {
+            "first-tool" to true
+            "third-tool" to json {
+                "second-child-tool" to "Second value"
+                "third-child-tool" to 3.4
+            }
+        }
+
+        val configJsonObject = tools.toJsonObjectOfValues { it.isEnabled }
+
+        assertEquals(expectedConfigJsonObject, configJsonObject)
     }
 
     @Test

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/MemorySourceConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/MemorySourceConfigActivity.kt
@@ -38,6 +38,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
 
         val source = DevToolsSources.memory(getTools())
         devtools = DevTools.create(source)
+
         devtools.onConfigUpdated = { isCriticalUpdate ->
             val toast = Toast.makeText(
                 this,


### PR DESCRIPTION
Closes: #37 

- [x] Unit tests  <!-- Check this if you covered your code with unit tests -->
- [x] Changelog <!-- Check this if you updated the changelog file  -->
- [x] Documentation (Readme) <!-- Check this if you updated the  documentation  -->

### What has been done
 Add `DevToolsStorage#getAllConfigAsJson` method which takes a filter parameter and returns a filtered JSON object of configuration values

### How to test
Usecase 1 
1. Go to any source Dev Tools Configuration screen
1. Add `val jsonConfiguration = devtools.getAllConfigAsJson()` inside the `onCreate` method
1. Place a breakpoint and check the `jsonConfiguration` result
1. Make sure the JSON configuration string contains all configuration values

Usecase 2 (Make sure the filter predicate works properly)
1. Go to any source Dev Tools Configuration screen
1. Add `val jsonConfiguration = devtools.getAllConfigAsJson { tool -> tool.isEnabled } ` inside the `onCreate` method
1. Place a breakpoint and check the `jsonConfiguration` result
1. Make sure the JSON configuration string contains all enabled configuration values 
You can try and experiment with different filters.
