### PR TITLE
Add ability to set dev tools state programmatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ Changelog
 =========
 
 ## Version 1.0.0 *(In development)*
+Issue: [#39](https://github.com/maximbircu/devtools-library/issues/39)
+- Add `DevTools#updateFromParams` which allows the library consumer to update the tools from a set of params(key-value pairs)
+- Add `DevTools#updateFromBundle` which allows the Android library consumer to update the tools from an Android bundle
+- Made each `DevTools` instance use a different storage key so that the similar tools don't collide
+
 Issue: [#37](https://github.com/maximbircu/devtools-library/issues/37)
 - Add DevToolsStorage#getAllConfigAsJson method, which takes a filter parameter and returns a filtered JSON string of configuration values
 

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/DevToolsExtensions.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/DevToolsExtensions.kt
@@ -8,5 +8,5 @@ fun DevTools.updateFromBundle(bundle: Bundle?) {
 }
 
 private fun Bundle.getArguments(): Map<String, Any> = keySet().map { key ->
-    key to requireNotNull(get(key)) { "A value was not provided for $key" }
+    key to requireNotNull(get(key)) { "No value provided for $key" }
 }.toMap()

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/DevToolsExtensions.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/DevToolsExtensions.kt
@@ -2,7 +2,18 @@ package com.maximbircu.devtools.android
 
 import android.os.Bundle
 import com.maximbircu.devtools.common.DevTools
+import com.maximbircu.devtools.common.DevToolsParser
 
+/**
+ * Updates all dev tools with argument values taken from [bundle].
+ * @see [intent arguments](https://developer.android.com/studio/command-line/adb.html#IntentSpec)
+ *
+ * Please, note that in case the tool you want to update using this method is a child of a
+ * [com.maximbircu.devtools.common.presentation.tools.group.GroupTool] then it's key should
+ * be prefixed with its parent key according to the logic the
+ * [com.maximbircu.devtools.common.core.DevTool.key] is set, i.e `group-tool-key.tool-to-update`
+ * @see DevToolsParser.getDevTools
+ */
 fun DevTools.updateFromBundle(bundle: Bundle?) {
     bundle?.getArguments()?.let(::updateFromParams)
 }

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/DevToolsExtensions.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/DevToolsExtensions.kt
@@ -1,0 +1,12 @@
+package com.maximbircu.devtools.android
+
+import android.os.Bundle
+import com.maximbircu.devtools.common.DevTools
+
+fun DevTools.updateFromBundle(bundle: Bundle?) {
+    bundle?.getArguments()?.let(::updateFromParams)
+}
+
+private fun Bundle.getArguments(): Map<String, Any> = keySet().map { key ->
+    key to requireNotNull(get(key)) { "A value was not provided for $key" }
+}.toMap()

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/extensions/DevToolsExtensions.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/extensions/DevToolsExtensions.kt
@@ -5,13 +5,13 @@ import com.maximbircu.devtools.common.DevTools
 import com.maximbircu.devtools.common.DevToolsParser
 
 /**
- * Updates all dev tools with argument values taken from [bundle].
+ * Updates all dev tools with argument values taken from the [bundle].
  * @see [intent arguments](https://developer.android.com/studio/command-line/adb.html#IntentSpec)
  *
  * Please, note that in case the tool you want to update using this method is a child of a
  * [com.maximbircu.devtools.common.presentation.tools.group.GroupTool] then it's key should
  * be prefixed with its parent key according to the logic the
- * [com.maximbircu.devtools.common.core.DevTool.key] is set, i.e `group-tool-key.tool-to-update`
+ * [com.maximbircu.devtools.common.core.DevTool.key] is set, i.e. `group-tool-key.tool-to-update`
  * @see DevToolsParser.getDevTools
  */
 fun DevTools.updateFromBundle(bundle: Bundle?) {

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/extensions/DevToolsExtensions.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/extensions/DevToolsExtensions.kt
@@ -15,9 +15,9 @@ import com.maximbircu.devtools.common.DevToolsParser
  * @see DevToolsParser.getDevTools
  */
 fun DevTools.updateFromBundle(bundle: Bundle?) {
-    bundle?.getArguments()?.let(::updateFromParams)
+    bundle?.let { updateFromParams(it.arguments) }
 }
 
-private fun Bundle.getArguments(): Map<String, Any> = keySet().map { key ->
-    key to requireNotNull(get(key)) { "No value provided for $key" }
-}.toMap()
+private val Bundle.arguments
+    get() = keySet().map { key -> key to requireNotNull(get(key)) { "No value provided for $key" } }
+        .toMap()

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/extensions/DevToolsExtensions.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/extensions/DevToolsExtensions.kt
@@ -1,4 +1,4 @@
-package com.maximbircu.devtools.android
+package com.maximbircu.devtools.android.extensions
 
 import android.os.Bundle
 import com.maximbircu.devtools.common.DevTools

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tool/DevToolLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tool/DevToolLayout.kt
@@ -74,9 +74,6 @@ abstract class DevToolLayout<T : DevTool<*>>(
     }
 
     override fun showHelpDialog(tool: DevTool<*>) {
-        DevToolHelpDialog(
-            context,
-            tool
-        ).show()
+        DevToolHelpDialog(context, tool).show()
     }
 }

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tool/DevToolLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tool/DevToolLayout.kt
@@ -9,6 +9,7 @@ import com.maximbircu.devtools.android.extensions.makeInvisible
 import com.maximbircu.devtools.android.extensions.setEnabledRecursively
 import com.maximbircu.devtools.android.extensions.setOnClickListener
 import com.maximbircu.devtools.android.extensions.show
+import com.maximbircu.devtools.android.presentation.tool.help.DevToolHelpDialog
 import com.maximbircu.devtools.common.core.DevTool
 import com.maximbircu.devtools.common.presentation.tool.DevToolPresenter
 import com.maximbircu.devtools.common.presentation.tool.DevToolView
@@ -73,6 +74,9 @@ abstract class DevToolLayout<T : DevTool<*>>(
     }
 
     override fun showHelpDialog(tool: DevTool<*>) {
-        DevToolHelpDialog(context, tool).show()
+        DevToolHelpDialog(
+            context,
+            tool
+        ).show()
     }
 }

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tool/help/DevToolHelpDialog.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tool/help/DevToolHelpDialog.kt
@@ -1,4 +1,4 @@
-package com.maximbircu.devtools.android.presentation.tool
+package com.maximbircu.devtools.android.presentation.tool.help
 
 import android.content.Context
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -12,10 +12,11 @@ import kotlinx.android.synthetic.main.layout_dev_tool_help_dialog.criticalUpdate
 import kotlinx.android.synthetic.main.layout_dev_tool_help_dialog.currentValue
 import kotlinx.android.synthetic.main.layout_dev_tool_help_dialog.defaultValue
 import kotlinx.android.synthetic.main.layout_dev_tool_help_dialog.description
+import kotlinx.android.synthetic.main.layout_dev_tool_help_dialog.startupArgument
 import kotlinx.android.synthetic.main.layout_dev_tool_help_dialog.toolKey
 
 class DevToolHelpDialog(
-    context: Context,
+    private val context: Context,
     private val tool: DevTool<*>
 ) : DevToolHelpDialogView {
     private val presenter = DevToolHelpDialogPresenter.create(this)
@@ -56,5 +57,13 @@ class DevToolHelpDialog(
 
     override fun hideCriticalUpdateLabel() {
         dialog.criticalUpdate.hide()
+    }
+
+    override fun showStartupArgument(key: String, value: Any) {
+        dialog.startupArgument.value = context.resources.getString(
+            R.string.dev_tool_help_dialog_startup_argument_value,
+            StartupArgumentFlagProvider.getFor(value),
+            key
+        )
     }
 }

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tool/help/StartupArgumentFlagProvider.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tool/help/StartupArgumentFlagProvider.kt
@@ -1,0 +1,12 @@
+package com.maximbircu.devtools.android.presentation.tool.help
+
+object StartupArgumentFlagProvider {
+    fun getFor(value: Any): String = when (value) {
+        is String -> "--es"
+        is Boolean -> "--ez"
+        is Int -> "--ei"
+        is Long -> "--el"
+        is Float, is Double -> "--ef"
+        else -> throw IllegalArgumentException("$value not supported!")
+    }
+}

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/readers/DevToolsSources.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/readers/DevToolsSources.kt
@@ -5,6 +5,7 @@ import com.maximbircu.devtools.android.readers.soruces.yaml.YamlDevToolsSource
 import com.maximbircu.devtools.common.core.DevTool
 import com.maximbircu.devtools.common.core.reader.DevToolsSource
 import com.maximbircu.devtools.common.readers.DevToolsSources
+import com.maximbircu.devtools.common.readers.json
 import java.io.InputStream
 
 /**
@@ -34,4 +35,18 @@ fun DevToolsSources.yaml(assetManager: AssetManager, inputStream: InputStream): 
  */
 fun DevToolsSources.yaml(assetManager: AssetManager, fileName: String): DevToolsSource {
     return yaml(assetManager, assetManager.open(fileName))
+}
+
+/**
+ * Provides a [JsonSchemaSource] which is a [DevToolsSource] implementation able to parse and
+ * generate a dictionary of [DevTool] from JSON schema.
+ *
+ * Use the provided source object as a parameter to [com.maximbircu.devtools.common.DevTools.create]
+ * to enable [com.maximbircu.devtools.common.DevTools] read and provide dev tools from a
+ * JSON schema config.
+ *
+ * @param jsonString a string which contains the dev tools configuration content in JSON format
+ */
+fun DevToolsSources.json(assetManager: AssetManager, fileName: String): DevToolsSource {
+    return json(assetManager.open(fileName).reader().readText())
 }

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/readers/DevToolsSources.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/readers/DevToolsSources.kt
@@ -38,14 +38,16 @@ fun DevToolsSources.yaml(assetManager: AssetManager, fileName: String): DevTools
 }
 
 /**
- * Provides a [JsonSchemaSource] which is a [DevToolsSource] implementation able to parse and
- * generate a dictionary of [DevTool] from JSON schema.
+ * Provides a [com.maximbircu.devtools.common.readers.sources.JsonSchemaSource] which is a
+ * [DevToolsSource] implementation able to parse and generate a dictionary of [DevTool] from a
+ * JSON schema.
  *
  * Use the provided source object as a parameter to [com.maximbircu.devtools.common.DevTools.create]
  * to enable [com.maximbircu.devtools.common.DevTools] read and provide dev tools from a
  * JSON schema config.
  *
- * @param jsonString a string which contains the dev tools configuration content in JSON format
+ * @param assetManager used to load the JSON file from your app assets
+ * @param fileName dev tools JSON configuration filename ex: "my-app-config.json"
  */
 fun DevToolsSources.json(assetManager: AssetManager, fileName: String): DevToolsSource {
     return json(assetManager.open(fileName).reader().readText())

--- a/devtools/android/src/main/res/layout/layout_dev_tool_help_dialog.xml
+++ b/devtools/android/src/main/res/layout/layout_dev_tool_help_dialog.xml
@@ -43,6 +43,13 @@
             app:title="@string/dev_tool_help_dialog_default_value"
             />
 
+        <com.maximbircu.devtools.android.presentation.tool.help.DevToolHelpDialogInfoRowLayout
+            android:id="@+id/startupArgument"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:title="Startup argument"
+            />
+
         <TextView
             android:id="@+id/criticalUpdate"
             android:layout_width="wrap_content"

--- a/devtools/android/src/main/res/layout/layout_dev_tool_help_dialog.xml
+++ b/devtools/android/src/main/res/layout/layout_dev_tool_help_dialog.xml
@@ -47,7 +47,7 @@
             android:id="@+id/startupArgument"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:title="Startup argument"
+            app:title="@string/dev_tool_help_dialog_startup_argument_title"
             />
 
         <TextView

--- a/devtools/android/src/main/res/layout/layout_enum_tool.xml
+++ b/devtools/android/src/main/res/layout/layout_enum_tool.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/selectorContainer"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
     android:theme="@style/Theme.DevTools"
     >
+    <FrameLayout
+        android:id="@+id/selectorContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        />
+
     <TextView
         android:id="@+id/currentValue"
         android:layout_width="wrap_content"

--- a/devtools/android/src/main/res/values/strings.xml
+++ b/devtools/android/src/main/res/values/strings.xml
@@ -24,6 +24,8 @@
     <string name="dev_tool_help_dialog_current_value">Current value</string>
     <string name="dev_tool_help_dialog_default_value">Default value</string>
     <string name="dev_tool_help_dialog_critical_update">Triggers a critical update!</string>
+    <string name="dev_tool_help_dialog_startup_argument_title">Triggers a critical update!</string>
+    <string name="dev_tool_help_dialog_startup_argument_value">%1$s %2$s &lt;your value></string>
 
     <!-- Group Tool Context Menu -->
     <string name="group_tool_context_menu_enable_all">Enable all</string>

--- a/devtools/android/src/main/res/values/strings.xml
+++ b/devtools/android/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="dev_tool_help_dialog_current_value">Current value</string>
     <string name="dev_tool_help_dialog_default_value">Default value</string>
     <string name="dev_tool_help_dialog_critical_update">Triggers a critical update!</string>
-    <string name="dev_tool_help_dialog_startup_argument_title">Triggers a critical update!</string>
+    <string name="dev_tool_help_dialog_startup_argument_title">Startup argument</string>
     <string name="dev_tool_help_dialog_startup_argument_value">%1$s %2$s &lt;your value></string>
 
     <!-- Group Tool Context Menu -->

--- a/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/DevToolsExtensionsKtTest.kt
+++ b/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/DevToolsExtensionsKtTest.kt
@@ -43,5 +43,6 @@ class DevToolsExtensionsKtTest : BaseTest() {
         every { bundle.get("text-tool") } returns expectedParams["text-tool"]
 
         assertFailsWith<IllegalArgumentException> { devTools.updateFromBundle(bundle) }
+        verify(exactly = 0) { devTools.updateFromParams(any()) }
     }
 }

--- a/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/DevToolsExtensionsKtTest.kt
+++ b/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/DevToolsExtensionsKtTest.kt
@@ -1,0 +1,46 @@
+package com.maximbircu.devtools.android
+
+import android.os.Bundle
+import com.maximbircu.devtools.android.utils.mockk
+import com.maximbircu.devtools.common.DevTools
+import io.mockk.every
+import io.mockk.verify
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+class DevToolsExtensionsKtTest : BaseTest() {
+    @Test
+    fun `extracts the params from bundle properly and updates the dev tools using them`() {
+        val devTools: DevTools = mockk()
+        val expectedParams = mapOf("toggle-tool" to true, "text-tool" to "Config value")
+        val bundle: Bundle = mockk()
+        every { bundle.keySet() } returns expectedParams.keys
+        every { bundle.get("toggle-tool") } returns expectedParams["toggle-tool"]
+        every { bundle.get("text-tool") } returns expectedParams["text-tool"]
+
+        devTools.updateFromBundle(bundle)
+
+        verify { devTools.updateFromParams(expectedParams) }
+    }
+
+    @Test
+    fun `doesn't update the tools in case the provided bundle is null`() {
+        val devTools: DevTools = mockk()
+
+        devTools.updateFromBundle(null)
+
+        verify(exactly = 0) { devTools.updateFromParams(any()) }
+    }
+
+    @Test
+    fun `throws exception in case the param value was not provided`() {
+        val devTools: DevTools = mockk()
+        val expectedParams = mapOf("toggle-tool" to true, "text-tool" to null)
+        val bundle: Bundle = mockk()
+        every { bundle.keySet() } returns expectedParams.keys
+        every { bundle.get("toggle-tool") } returns expectedParams["toggle-tool"]
+        every { bundle.get("text-tool") } returns expectedParams["text-tool"]
+
+        assertFailsWith<IllegalArgumentException> { devTools.updateFromBundle(bundle) }
+    }
+}

--- a/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/DevToolsExtensionsKtTest.kt
+++ b/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/DevToolsExtensionsKtTest.kt
@@ -1,6 +1,7 @@
 package com.maximbircu.devtools.android
 
 import android.os.Bundle
+import com.maximbircu.devtools.android.extensions.updateFromBundle
 import com.maximbircu.devtools.android.utils.mockk
 import com.maximbircu.devtools.common.DevTools
 import io.mockk.every

--- a/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/presentation/tool/help/StartupArgumentFlagProviderTest.kt
+++ b/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/presentation/tool/help/StartupArgumentFlagProviderTest.kt
@@ -1,0 +1,57 @@
+package com.maximbircu.devtools.android.presentation.tool.help
+
+import com.maximbircu.devtools.android.BaseTest
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class StartupArgumentFlagProviderTest : BaseTest() {
+    @Test
+    fun `returns "--es" startup argument flag for a string value`() {
+        val flag = StartupArgumentFlagProvider.getFor("String config value")
+
+        assertEquals("--es", flag)
+    }
+
+    @Test
+    fun `returns "--ez" startup argument flag for a boolean value`() {
+        val flag = StartupArgumentFlagProvider.getFor(true)
+
+        assertEquals("--ez", flag)
+    }
+
+    @Test
+    fun `returns "--ei" startup argument flag for a int value`() {
+        val flag = StartupArgumentFlagProvider.getFor(1)
+
+        assertEquals("--ei", flag)
+    }
+
+    @Test
+    fun `returns "--el" startup argument flag for a long value`() {
+        val flag = StartupArgumentFlagProvider.getFor(1L)
+
+        assertEquals("--el", flag)
+    }
+
+    @Test
+    fun `returns "--ef" startup argument flag for a float value`() {
+        val flag = StartupArgumentFlagProvider.getFor(1f)
+
+        assertEquals("--ef", flag)
+    }
+
+    @Test
+    fun `returns "--ef" startup argument flag for a double value`() {
+        val flag = StartupArgumentFlagProvider.getFor(1.0)
+
+        assertEquals("--ef", flag)
+    }
+
+    @Test
+    fun `throws exception for a unknown startup argument flag`() {
+        assertFailsWith<IllegalArgumentException> {
+            StartupArgumentFlagProvider.getFor(object {})
+        }
+    }
+}

--- a/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/readers/DevToolsSourcesKtTest.kt
+++ b/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/readers/DevToolsSourcesKtTest.kt
@@ -1,11 +1,17 @@
 package com.maximbircu.devtools.android.readers
 
+import android.content.res.AssetManager
 import com.maximbircu.devtools.android.BaseTest
 import com.maximbircu.devtools.android.readers.soruces.yaml.YamlDevToolsSource
 import com.maximbircu.devtools.android.utils.mockk
+import com.maximbircu.devtools.common.core.reader.DevToolsSource
 import com.maximbircu.devtools.common.readers.DevToolsSources
+import com.maximbircu.devtools.common.readers.json
+import io.mockk.every
+import io.mockk.mockkStatic
 import org.junit.Test
 import java.io.InputStream
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class DevToolsSourcesKtTest : BaseTest() {
@@ -21,5 +27,18 @@ class DevToolsSourcesKtTest : BaseTest() {
         val source = DevToolsSources.yaml(mockk(relaxed = true), "dev-tools.yml")
 
         assertTrue(source is YamlDevToolsSource)
+    }
+
+    @Test
+    fun `returns a proper json schema source`() {
+        mockkStatic("com.maximbircu.devtools.common.readers.DevToolsSourcesKt")
+        val assetManager = mockk<AssetManager>(relaxed = true)
+        every { assetManager.open(any()) } returns "".byteInputStream()
+        val expectedSource: DevToolsSource = mockk()
+        every { DevToolsSources.json(any()) } returns expectedSource
+
+        val source = DevToolsSources.json(assetManager, "dev-tools.json")
+
+        assertEquals(expectedSource, source)
     }
 }

--- a/devtools/common/src/androidMain/kotlin/com/maximbircu/devtools/common/stores/PreferencesToolStoreImpl.kt
+++ b/devtools/common/src/androidMain/kotlin/com/maximbircu/devtools/common/stores/PreferencesToolStoreImpl.kt
@@ -10,7 +10,9 @@ import com.maximbircu.devtools.common.put
 actual open class PreferencesToolStoreImpl<T : Any> actual constructor(
     private val tool: DevTool<T>
 ) : PreferencesToolStore<T> {
-    private var preferences = SharedPreferencesProvider.getSharedPreferences("DEV_TOOLS")
+    private var preferences = SharedPreferencesProvider.getSharedPreferences(
+        "DEV_TOOLS_${tool.containerName}"
+    )
 
     override var isEnabled: Boolean
         set(value) { preferences.edit().putBoolean("${tool.key}_enabled", value).commit() }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
@@ -1,5 +1,6 @@
 package com.maximbircu.devtools.common
 
+import com.maximbircu.devtools.common.core.DevTool
 import com.maximbircu.devtools.common.core.reader.DevToolsSource
 import com.maximbircu.devtools.common.extensions.forEachRecursively
 
@@ -71,7 +72,8 @@ private class DevToolsImpl(
             params[tool.key]?.let { paramValue ->
                 println(paramValue)
                 tool.isEnabled = true
-                tool.set(paramValue)
+                @Suppress("UNCHECKED_CAST")
+                (tool as DevTool<Any>).value = paramValue
             }
         }
         persistToolsState()

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
@@ -21,6 +21,19 @@ interface DevTools : DevToolsStorage {
      */
     fun persistToolsState()
 
+    /**
+     * Updates all dev tools with values taken from [params].
+     *
+     * @param params a collection of key-value pairs where the key is
+     * [com.maximbircu.devtools.common.core.DevTool.key] and the value is the new config value the
+     * tool should take
+     *
+     * Please, note that in case the tool you want to update using this method is a child of a
+     * [com.maximbircu.devtools.common.presentation.tools.group.GroupTool] then it's key should
+     * be prefixed with its parent key according to the logic the
+     * [com.maximbircu.devtools.common.core.DevTool.key] is set, i.e `group-tool-key.tool-to-update`
+     * @see DevToolsParser.getDevTools
+     */
     fun updateFromParams(params: Map<String, Any>)
 
     companion object {

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
@@ -56,6 +56,7 @@ private class DevToolsImpl(
         if (params.isEmpty()) return
         tools.forEachRecursively { _, tool ->
             params[tool.key]?.let { paramValue ->
+                println(paramValue)
                 tool.isEnabled = true
                 tool.set(paramValue)
             }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
@@ -21,6 +21,8 @@ interface DevTools : DevToolsStorage {
      */
     fun persistToolsState()
 
+    fun updateFromParams(params: Map<String, Any>)
+
     companion object {
         /**
          * Crates a new instance of [DevTools].
@@ -48,6 +50,17 @@ private class DevToolsImpl(
 ) : DevTools, DevToolsStorage by toolsStorage {
     init {
         tools.forEachRecursively { _, tool -> tool.restorePersistedState() }
+    }
+
+    override fun updateFromParams(params: Map<String, Any>) {
+        if (params.isEmpty()) return
+        tools.forEachRecursively { _, tool ->
+            params[tool.key]?.let { paramValue ->
+                tool.isEnabled = true
+                tool.set(paramValue)
+            }
+        }
+        persistToolsState()
     }
 
     override fun persistToolsState() {

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevToolsParser.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevToolsParser.kt
@@ -2,24 +2,29 @@ package com.maximbircu.devtools.common
 
 import com.maximbircu.devtools.common.core.DevTool
 import com.maximbircu.devtools.common.core.reader.DevToolsSource
+import com.maximbircu.devtools.common.extensions.forEachRecursively
 import com.maximbircu.devtools.common.presentation.tools.group.GroupTool
 
 interface DevToolsParser {
     fun getDevTools(): Map<String, DevTool<*>>
 
     companion object {
-        fun create(devToolsSources: List<DevToolsSource>): DevToolsParser {
-            return DevToolsParserImpl(devToolsSources)
+        fun create(containerName: String, devToolsSources: List<DevToolsSource>): DevToolsParser {
+            return DevToolsParserImpl(containerName, devToolsSources)
         }
     }
 }
 
-private class DevToolsParserImpl(private val sources: List<DevToolsSource>) : DevToolsParser {
+private class DevToolsParserImpl(
+    private val containerName: String,
+    private val sources: List<DevToolsSource>
+) : DevToolsParser {
     override fun getDevTools(): Map<String, DevTool<*>> {
         val readers = sources.map { it.getReader() }
         return readers.fold(mapOf()) { accumulator, reader ->
             val tools = reader.getDevTools()
             tools.setKeys()
+            tools.forEachRecursively { _, tool -> tool.containerName = containerName }
             accumulator + tools
         }
     }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
@@ -21,12 +21,7 @@ abstract class DevTool<T : Any>(
     var isCritical: Boolean = false
 ) {
     private var _key: String? = null
-
-    /**
-     * This property will be true in case the in-memory tool state will be different from the
-     * persisted one.
-     */
-    val hasUnsavedChanges: Boolean get() = value != store.value || isEnabled != store.isEnabled
+    private var _toolsContainer: String? = null
 
     /**
      * A unique dev tool identifier.
@@ -35,8 +30,24 @@ abstract class DevTool<T : Any>(
         get() = _key ?: throw NullPointerException("Dev tool key was not set!")
         set(value) {
             _key = value
-            restorePersistedState()
         }
+
+    /**
+     * The name of the tool container.
+     * This should be used to differentiate between tools with the same key but in different
+     * [com.maximbircu.devtools.common.DevTools] instances.
+     */
+    var containerName: String
+        get() = _toolsContainer ?: throw NullPointerException("Dev tool container was not set!")
+        set(value) {
+            _toolsContainer = value
+        }
+
+    /**
+     * This property will be true in case the in-memory tool state will be different from the
+     * persisted one.
+     */
+    val hasUnsavedChanges: Boolean get() = value != store.value || isEnabled != store.isEnabled
 
     /**
      * The dev tool configuration value at the moment, note that this is kept just in memory and

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
@@ -104,6 +104,13 @@ abstract class DevTool<T : Any>(
         value = store.value
         isEnabled = store.isEnabled
     }
+
+    @Suppress("UNCHECKED_CAST")
+    fun set(value: Any) {
+        if(this.value::class == value::class) {
+            this.value = value as T
+        }
+    }
 }
 
 /**

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
@@ -107,7 +107,7 @@ abstract class DevTool<T : Any>(
 
     @Suppress("UNCHECKED_CAST")
     fun set(value: Any) {
-        if(this.value::class == value::class) {
+        if (this.value::class == value::class) {
             this.value = value as T
         }
     }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt
@@ -104,13 +104,6 @@ abstract class DevTool<T : Any>(
         value = store.value
         isEnabled = store.isEnabled
     }
-
-    @Suppress("UNCHECKED_CAST")
-    fun set(value: Any) {
-        if (this.value::class == value::class) {
-            this.value = value as T
-        }
-    }
 }
 
 /**

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/help/DevToolHelpDialogPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/help/DevToolHelpDialogPresenter.kt
@@ -39,6 +39,7 @@ private class DevToolHelpDialogPresenterImpl(
         view.setDefaultConfigValue(tool.getDefaultValue().toString())
         view.bindDescription(tool.description)
         view.bindCriticalUpdateInfo(tool.isCritical)
+        view.showStartupArgument(tool.key, tool.value)
     }
 
     private fun DevToolHelpDialogView.bindDescription(description: String) {

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/help/DevToolHelpDialogView.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/help/DevToolHelpDialogView.kt
@@ -56,4 +56,14 @@ interface DevToolHelpDialogView : BaseView {
      * critical update because the tool is not critical.
      */
     fun hideCriticalUpdateLabel()
+
+    /**
+     * Should show an example of startup argument the user could use to update the configuration
+     * value from the startup arguments.
+     *
+     * @param key the tool key which will be used to identify the tool that should be updated
+     * @param value the tool current configuration value, might be used to extract the config
+     * value type in case startup arguments will be different for different types
+     */
+    fun showStartupArgument(key: String, value: Any)
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
@@ -138,10 +138,8 @@ class DevToolsImplTest : BaseTest() {
 
         verify { tools.getValue("first-tool").isEnabled = true }
         verify { childTools.getValue("second-tool").isEnabled = true }
-
         verify { tools.getValue("first-tool") setProperty "value" value false }
         verify { childTools.getValue("second-tool") setProperty "value" value "New config value" }
-
         verify { devTools.persistToolsState() }
     }
 
@@ -165,15 +163,12 @@ class DevToolsImplTest : BaseTest() {
             }
         )
         val devTools = spyk(DevTools.create("TEST", DevToolsSources.memory(tools)))
-
         clearAllMocks()
+
         devTools.updateFromParams(emptyMap())
 
-        tools.values.forEach { tool ->
-            verify { tool wasNot Called }
-        }
+        tools.values.forEach { tool -> verify { tool wasNot Called } }
         childTools.values.forEach { tool -> verify { tool wasNot Called } }
-
         verify(exactly = 0) { devTools.persistToolsState() }
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
@@ -1,6 +1,7 @@
 package com.maximbircu.devtools.common
 
 import com.maximbircu.devtools.common.core.createTool
+import com.maximbircu.devtools.common.extensions.forEachRecursively
 import com.maximbircu.devtools.common.mvp.BaseTest
 import com.maximbircu.devtools.common.presentation.tools.group.GroupTool
 import com.maximbircu.devtools.common.presentation.tools.text.TextTool
@@ -14,6 +15,23 @@ import kotlin.test.Test
 
 class DevToolsImplTest : BaseTest() {
     @Test
+    fun `restores persisted state`() {
+        val tools = mapOf(
+            "first-tool" to createTool { ::hasUnsavedChanges returns true },
+            "second-tool" to createTool<GroupTool> {
+                ::tools returns mapOf(
+                    "first-child-tool" to createTool<ToggleTool>(),
+                    "second-child-tool" to createTool<TextTool> { ::hasUnsavedChanges returns true }
+                )
+            }
+        )
+
+        DevTools.create("TEST", DevToolsSources.memory(tools))
+
+        tools.forEachRecursively { _, tool -> verify { tool.restorePersistedState() } }
+    }
+
+    @Test
     fun `persists tool state in case it has unsaved changes`() {
         val childTools = mapOf(
             "first-child-tool" to createTool<ToggleTool>(),
@@ -23,7 +41,7 @@ class DevToolsImplTest : BaseTest() {
             "first-tool" to createTool { ::hasUnsavedChanges returns true },
             "second-tool" to createTool<GroupTool> { ::tools returns childTools }
         )
-        val devTools = DevTools.create(DevToolsSources.memory(tools))
+        val devTools = DevTools.create("TEST", DevToolsSources.memory(tools))
 
         devTools.persistToolsState()
 
@@ -35,6 +53,7 @@ class DevToolsImplTest : BaseTest() {
     fun `notifies the listener about tools config update if at least one tool was updated`() {
         val onConfigUpdate: (Boolean) -> Unit = mockk(relaxed = true)
         val devTools = DevTools.create(
+            "TEST",
             DevToolsSources.memory(
                 mapOf(
                     "first-tool" to createTool { ::hasUnsavedChanges returns true },
@@ -53,6 +72,7 @@ class DevToolsImplTest : BaseTest() {
     fun `doesn't notify the listener about tools critical config update if there are no changes`() {
         val onConfigUpdate: (Boolean) -> Unit = mockk(relaxed = true)
         val devTools = DevTools.create(
+            "TEST",
             DevToolsSources.memory(mapOf("first-tool" to createTool())),
             onConfigUpdate = onConfigUpdate
         )
@@ -66,6 +86,7 @@ class DevToolsImplTest : BaseTest() {
     fun `notifies the listener about tools critical config update if at least one happened`() {
         val onConfigUpdate: (Boolean) -> Unit = mockk(relaxed = true)
         val devTools = DevTools.create(
+            "TEST",
             DevToolsSources.memory(
                 mapOf(
                     "first-tool" to createTool {

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
@@ -110,7 +110,7 @@ class DevToolsImplTest : BaseTest() {
 
     @Test
     fun `updates dev tools from provided params`() {
-        val childTools = mapOf<String, DevTool<*>>(
+        val childTools = mapOf(
             "first-tool" to createTool { ::key returns "group-tool.first-tool" },
             "second-tool" to createTool<TextTool> {
                 ::key returns "group-tool.second-tool"
@@ -139,8 +139,8 @@ class DevToolsImplTest : BaseTest() {
         verify { tools.getValue("first-tool").isEnabled = true }
         verify { childTools.getValue("second-tool").isEnabled = true }
 
-        verify { tools.getValue("first-tool").set(false) }
-        verify { childTools.getValue("second-tool").set("New config value") }
+        verify { tools.getValue("first-tool") setProperty "value" value false }
+        verify { childTools.getValue("second-tool") setProperty "value" value "New config value" }
 
         verify { devTools.persistToolsState() }
     }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsParserImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsParserImplTest.kt
@@ -20,13 +20,14 @@ class DevToolsParserImplTest : BaseTest() {
             "first-source-first-tool" to createTool(),
             "first-source-second-tool" to createTool()
         )
+        val childTools = mapOf<String, DevTool<*>>("child-tool" to createTool())
         val source2Tools = mapOf<String, DevTool<*>>(
             "second-source-first-tool" to createTool(),
             "second-source-second-tool" to createTool(),
-            "group-tool" to spyk(GroupTool(mapOf("child-tool" to createTool())))
+            "group-tool" to spyk(GroupTool(childTools))
         )
         val sources = listOf(createSource(source1Tools), createSource(source2Tools))
-        val parser = DevToolsParser.create(sources)
+        val parser = DevToolsParser.create("CONTAINER_NAME", sources)
 
         val tools = parser.getDevTools()
 
@@ -37,10 +38,16 @@ class DevToolsParserImplTest : BaseTest() {
         verify { tools.getValue("second-source-first-tool").key = "second-source-first-tool" }
         verify { tools.getValue("second-source-second-tool").key = "second-source-second-tool" }
 
-        val childTools = (tools.getValue("group-tool") as GroupTool).tools
-        println(childTools.getValue("child-tool").key)
         verify { tools.getValue("group-tool").key = "group-tool" }
         verify { childTools.getValue("child-tool").key = "group-tool.child-tool" }
+
+        verify { tools.getValue("first-source-first-tool").containerName = "CONTAINER_NAME" }
+        verify { tools.getValue("first-source-second-tool").containerName = "CONTAINER_NAME" }
+        verify { tools.getValue("second-source-first-tool").containerName = "CONTAINER_NAME" }
+        verify { tools.getValue("second-source-second-tool").containerName = "CONTAINER_NAME" }
+
+        verify { tools.getValue("group-tool").containerName = "CONTAINER_NAME" }
+        verify { childTools.getValue("child-tool").containerName = "CONTAINER_NAME" }
     }
 
     private fun createSource(tools: Map<String, DevTool<*>>) = object : DevToolsSource {

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/core/DevToolTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/core/DevToolTest.kt
@@ -14,18 +14,6 @@ class DevToolTest : BaseTest() {
     private val store: ToolStore<String> = mockk(relaxed = true)
 
     @Test
-    fun `restores proper persisted state when tool key updated`() {
-        val devTool = createDevTool()
-        every { store.isEnabled } returns false
-        every { store.value } returns "Configuration value"
-
-        devTool.key = "some-key"
-
-        assertFalse(devTool.isEnabled)
-        assertEquals("Configuration value", devTool.value)
-    }
-
-    @Test
     fun `persists dev tool state`() {
         val devTool = createDevTool()
         devTool.isEnabled = false
@@ -59,7 +47,7 @@ class DevToolTest : BaseTest() {
         val devTool = createDevTool()
         every { store.isEnabled } returns false
         every { store.value } returns "Configuration value"
-        devTool.key = "some-key"
+        devTool.restorePersistedState()
 
         assertFalse(devTool.hasUnsavedChanges)
     }
@@ -69,7 +57,7 @@ class DevToolTest : BaseTest() {
         val devTool = createDevTool()
         every { store.isEnabled } returns false
         every { store.value } returns "Configuration value"
-        devTool.key = "some-key"
+        devTool.restorePersistedState()
 
         devTool.isEnabled = false
         devTool.value = "New configuration value"
@@ -94,7 +82,7 @@ class DevToolTest : BaseTest() {
         val devTool = createDevTool()
         every { store.isEnabled } returns false
         every { store.value } returns "Configuration value"
-        devTool.key = "some-key"
+        devTool.restorePersistedState()
 
         devTool.isEnabled = true
         devTool.value = "New configuration value"
@@ -109,6 +97,13 @@ class DevToolTest : BaseTest() {
         val devTool = createDevTool()
 
         assertFailsWith(NullPointerException::class) { devTool.key }
+    }
+
+    @Test
+    fun `throws exception when trying to access tool containerName if it was not set`() {
+        val devTool = createDevTool()
+
+        assertFailsWith(NullPointerException::class) { devTool.containerName }
     }
 
     private fun createDevTool(

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/core/DevToolTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/core/DevToolTest.kt
@@ -100,10 +100,28 @@ class DevToolTest : BaseTest() {
     }
 
     @Test
+    fun `returns tool key if it was set`() {
+        val devTool = createDevTool()
+
+        devTool.key = "group-tool.toggle-tool"
+
+        assertEquals("group-tool.toggle-tool", devTool.key)
+    }
+
+    @Test
     fun `throws exception when trying to access tool containerName if it was not set`() {
         val devTool = createDevTool()
 
         assertFailsWith(NullPointerException::class) { devTool.containerName }
+    }
+
+    @Test
+    fun `returns tool container if it was set`() {
+        val devTool = createDevTool()
+
+        devTool.containerName = "TEST"
+
+        assertEquals("TEST", devTool.containerName)
     }
 
     private fun createDevTool(

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolHelpDialogPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolHelpDialogPresenterImplTest.kt
@@ -5,6 +5,7 @@ import com.maximbircu.devtools.common.core.createTool
 import com.maximbircu.devtools.common.mvp.BasePresenterTest
 import com.maximbircu.devtools.common.presentation.tool.help.DevToolHelpDialogPresenter
 import com.maximbircu.devtools.common.presentation.tool.help.DevToolHelpDialogView
+import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
 import com.maximbircu.devtools.common.utils.mockk
 import com.maximbircu.devtools.common.utils.returns
 import io.mockk.verify
@@ -65,6 +66,18 @@ class DevToolHelpDialogPresenterImplTest :
         presenter.onToolBind(tool)
 
         verify { view.setDefaultConfigValue("Default configuration value") }
+    }
+
+    @Test
+    fun `shows startup argument on tool bind`() {
+        val tool: DevTool<*> = createTool<ToggleTool> {
+            ::key returns "toggle-tool"
+            ::value returns true
+        }
+
+        presenter.onToolBind(tool)
+
+        verify { view.showStartupArgument("toggle-tool", true) }
     }
 
     @Test

--- a/devtools/common/src/iosMain/kotlin/com/maximbircu/devtools/common/stores/PreferencesToolStoreImpl.kt
+++ b/devtools/common/src/iosMain/kotlin/com/maximbircu/devtools/common/stores/PreferencesToolStoreImpl.kt
@@ -7,7 +7,7 @@ import platform.darwin.NSInteger
 actual open class PreferencesToolStoreImpl<T : Any> actual constructor(
     private val tool: DevTool<T>
 ) : PreferencesToolStore<T> {
-    private val nsUserDefaults: NSUserDefaults = NSUserDefaults("DEV_TOOLS")
+    private val nsUserDefaults: NSUserDefaults = NSUserDefaults("DEV_TOOLS_${tool.containerName}")
 
     override var isEnabled: Boolean
         set(value) { nsUserDefaults.setBool(value, "${tool.key}_enabled") }

--- a/devtools/ios/DevtoolsFramework/DevToolsConfiguration.swift
+++ b/devtools/ios/DevtoolsFramework/DevToolsConfiguration.swift
@@ -7,6 +7,6 @@ public final class DevToolsConfiguration {
 
     private func initSource(devTools: [String: DevTool]) {
         let source = DevToolsSources().memory(devTools: devTools)
-        _ = DevToolsCompanion().create(devToolsSource: KotlinArray(size: 1) { _ in source }) { _ in }
+        _ = DevToolsCompanion().create(name: "MEMORY", devToolsSource: KotlinArray(size: 1) { _ in source }) { _ in }
     }
 }

--- a/samples/android/src/main/assets/dev-tools.json
+++ b/samples/android/src/main/assets/dev-tools.json
@@ -2,28 +2,28 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "schema-toggle-tool": {
+    "toggle-tool": {
       "type": "boolean",
       "title": "Toggle tool",
       "description": "A boolean configuration value tool",
       "default": true
     },
 
-    "schema-text-tool": {
+    "text-tool": {
       "type": "string",
       "title": "Text tool (String)",
       "description": "A text configuration value tool",
       "default": "String config value",
       "hint": "String config value"
     },
-    "schema-text-tool-integer": {
+    "text-tool-integer": {
       "type": "integer",
       "title": "Text tool (Integer)",
       "description": "An integer number configuration value tool",
       "default": 3,
       "hint": "Integer number config value"
     },
-    "schema-text-tool-floating-point": {
+    "text-tool-floating-point": {
       "type": "number",
       "title": "Text tool (Floating point)",
       "description": "A floating-point number configuration value tool",
@@ -31,7 +31,7 @@
       "hint": "Floating point number config value"
     },
 
-    "schema-enum-tool-floating-point": {
+    "enum-tool-floating-point": {
       "type": "string",
       "title": "Enum tool",
       "default": "Second Option Value",
@@ -43,23 +43,23 @@
       "allowCustom": true
     },
 
-    "schema-tools-group": {
+    "tools-group": {
       "type": "object",
       "title": "Tools group",
       "properties": {
-        "schema-toggle-tool": {
+        "toggle-tool": {
           "type": "boolean",
           "title": "Toggle tool",
           "description": "A boolean configuration value tool"
         },
-        "schema-text-tool": {
+        "text-tool": {
           "type": "string",
           "title": "Text tool (String)",
           "description": "A text configuration value tool",
           "default": " String config value",
           "hint": "String config value"
         },
-        "schema-enum-tool-floating-point": {
+        "enum-tool-floating-point": {
           "type": "string",
           "title": "Enum tool",
           "default": "Second Option Value",

--- a/samples/android/src/main/assets/dev-tools.json
+++ b/samples/android/src/main/assets/dev-tools.json
@@ -2,28 +2,28 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "json-schema-toggle-tool": {
+    "schema-toggle-tool": {
       "type": "boolean",
       "title": "Toggle tool",
       "description": "A boolean configuration value tool",
       "default": true
     },
 
-    "json-schema-text-tool": {
+    "schema-text-tool": {
       "type": "string",
       "title": "Text tool (String)",
       "description": "A text configuration value tool",
       "default": "String config value",
       "hint": "String config value"
     },
-    "json-schema-text-tool-integer": {
+    "schema-text-tool-integer": {
       "type": "integer",
       "title": "Text tool (Integer)",
       "description": "An integer number configuration value tool",
       "default": 3,
       "hint": "Integer number config value"
     },
-    "json-schema-text-tool-floating-point": {
+    "schema-text-tool-floating-point": {
       "type": "number",
       "title": "Text tool (Floating point)",
       "description": "A floating-point number configuration value tool",
@@ -31,7 +31,7 @@
       "hint": "Floating point number config value"
     },
 
-    "json-schema-enum-tool-floating-point": {
+    "schema-enum-tool-floating-point": {
       "type": "string",
       "title": "Enum tool",
       "default": "Second Option Value",
@@ -43,23 +43,23 @@
       "allowCustom": true
     },
 
-    "json-schema-tools-group": {
+    "schema-tools-group": {
       "type": "object",
       "title": "Tools group",
       "properties": {
-        "json-schema-toggle-tool": {
+        "schema-toggle-tool": {
           "type": "boolean",
           "title": "Toggle tool",
           "description": "A boolean configuration value tool"
         },
-        "json-schema-text-tool": {
+        "schema-text-tool": {
           "type": "string",
           "title": "Text tool (String)",
           "description": "A text configuration value tool",
           "default": " String config value",
           "hint": "String config value"
         },
-        "json-schema-enum-tool-floating-point": {
+        "schema-enum-tool-floating-point": {
           "type": "string",
           "title": "Enum tool",
           "default": "Second Option Value",

--- a/samples/android/src/main/assets/dev-tools.yml
+++ b/samples/android/src/main/assets/dev-tools.yml
@@ -2,7 +2,7 @@
 ## Boolean
 ##############################
 
-yml-toggle-tool: !toggle {
+toggle-tool: !toggle {
   title: "Toggle tool",
   description: "A boolean configuration value tool",
   canBeDisabled: true,
@@ -14,7 +14,7 @@ yml-toggle-tool: !toggle {
 ## String
 ##############################
 
-yml-text-tool: !text {
+text-tool: !text {
   title: "Text tool (String)",
   description: "A text configuration value tool",
   canBeDisabled: true,
@@ -28,7 +28,7 @@ yml-text-tool: !text {
 ## Integer
 ##############################
 
-yml-text-tool-integer: !text {
+text-tool-integer: !text {
   title: "Text tool (Integer)",
   description: "An integer number configuration value tool",
   canBeDisabled: true,
@@ -42,7 +42,7 @@ yml-text-tool-integer: !text {
 ## Floating point
 ##############################
 
-yml-text-tool-floating-point: !text {
+text-tool-floating-point: !text {
   title: "Text tool (Floating point)",
   description: "A floating-point number configuration value tool",
   canBeDisabled: true,
@@ -56,7 +56,7 @@ yml-text-tool-floating-point: !text {
 ## Time
 ##############################
 
-yml-time-tool: !time {
+time-tool: !time {
   title: "Time tool",
   description: "A time configuration value tool",
   canBeDisabled: true,
@@ -73,7 +73,7 @@ yml-time-tool: !time {
 ## Enum
 ##############################
 
-yml-enum-tool: !enum {
+enum-tool: !enum {
   title: "Enum tool",
   description: "An enum configuration value tool",
   canBeDisabled: true,
@@ -88,7 +88,7 @@ yml-enum-tool: !enum {
   }
 }
 
-yml-enum-custom-options-provider-tool: !enum {
+enum-custom-options-provider-tool: !enum {
   title: "Enum tool [Custom Provider]",
   description: "An enum configuration value tool with a custom options provider",
   canBeDisabled: true,
@@ -105,17 +105,17 @@ yml-enum-custom-options-provider-tool: !enum {
 ## Group
 ##############################
 
-yml-tools-group: !group {
+tools-group: !group {
   title: "Tools group",
   tools: {
-    yml-toggle-tool: !toggle {
+    toggle-tool: !toggle {
       title: "Toggle tool",
       description: "A boolean configuration value tool",
       canBeDisabled: true,
       defaultEnabledValue: false,
       isCritical: false
     },
-    yml-text-tool: !text {
+    text-tool: !text {
       title: "Text tool (String)",
       description: "A text configuration value tool",
       canBeDisabled: true,
@@ -124,7 +124,7 @@ yml-tools-group: !group {
       defaultValue: "Here can go any text value",
       hint: "String config value"
     },
-    yml-time-tool: !time {
+    time-tool: !time {
       title: "Time tool",
       description: "A time configuration value tool",
       canBeDisabled: true,
@@ -136,7 +136,7 @@ yml-tools-group: !group {
       seconds: 4,
       milliseconds: 5,
     },
-    yml-enum-tool: !enum {
+    enum-tool: !enum {
       title: "Enum tool",
       description: "An enum configuration value tool",
       canBeDisabled: true,

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/MainActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/MainActivity.kt
@@ -2,6 +2,7 @@ package com.maximbircu.devtools
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.maximbircu.devtools.android.updateFromBundle
 import com.maximbircu.devtools.configscreens.CombinedSourcesConfigActivity
 import com.maximbircu.devtools.configscreens.JsonSchemaSourceConfigActivity
 import com.maximbircu.devtools.configscreens.MemorySourceConfigActivity
@@ -20,5 +21,10 @@ class MainActivity : AppCompatActivity() {
         yamlSourceTools.setOnClickListener { YamlSourceConfigActivity.start(this) }
         jsonSchemaSourceTools.setOnClickListener { JsonSchemaSourceConfigActivity.start(this) }
         combinedSourceTools.setOnClickListener { CombinedSourcesConfigActivity.start(this) }
+
+        SampleApplication.application.memoryDevTools.updateFromBundle(intent.extras)
+        SampleApplication.application.yamlDevTools.updateFromBundle(intent.extras)
+        SampleApplication.application.jsonDevTools.updateFromBundle(intent.extras)
+        SampleApplication.application.combinedDevTools.updateFromBundle(intent.extras)
     }
 }

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/MainActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/MainActivity.kt
@@ -2,7 +2,7 @@ package com.maximbircu.devtools
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.maximbircu.devtools.android.updateFromBundle
+import com.maximbircu.devtools.android.extensions.updateFromBundle
 import com.maximbircu.devtools.configscreens.CombinedSourcesConfigActivity
 import com.maximbircu.devtools.configscreens.JsonSchemaSourceConfigActivity
 import com.maximbircu.devtools.configscreens.MemorySourceConfigActivity

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/MemoryDevToolsProvider.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/MemoryDevToolsProvider.kt
@@ -8,6 +8,7 @@ import com.maximbircu.devtools.common.presentation.tools.text.TextTool
 import com.maximbircu.devtools.common.presentation.tools.time.TimeTool
 import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
 
+@Suppress("LargeClass")
 object MemoryDevToolsProvider {
     val tools: Map<String, DevTool<*>>
         get() = mapOf(
@@ -152,4 +153,3 @@ object MemoryDevToolsProvider {
             forEach { (key, value) -> value.key = key }
         }
 }
-

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/MemoyrDevToolsProvider.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/MemoyrDevToolsProvider.kt
@@ -1,0 +1,155 @@
+package com.maximbircu.devtools
+
+import com.maximbircu.devtools.common.core.DevTool
+import com.maximbircu.devtools.common.presentation.tools.enum.EnumOptionsProvider
+import com.maximbircu.devtools.common.presentation.tools.enum.EnumTool
+import com.maximbircu.devtools.common.presentation.tools.group.GroupTool
+import com.maximbircu.devtools.common.presentation.tools.text.TextTool
+import com.maximbircu.devtools.common.presentation.tools.time.TimeTool
+import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
+
+object MemoryDevToolsProvider {
+    val tools: Map<String, DevTool<*>>
+        get() = mapOf(
+            "toggle-tool" to ToggleTool(defaultValue = false).apply {
+                title = "Toggle tool"
+                description = "A boolean configuration value dev tool"
+                canBeDisabled = true
+                defaultEnabledValue = false
+                isCritical = true
+            },
+
+            "text-tool" to TextTool(
+                defaultValue = "Here can go any text value",
+                hint = "String config value"
+            ).apply {
+                title = "Text tool (String)"
+                description = "A text configuration value tool"
+                canBeDisabled = true
+                defaultEnabledValue = false
+                isCritical = false
+            },
+            "text-tool-integer" to TextTool(
+                defaultValue = 3,
+                hint = "Integer number config value"
+            ).apply {
+                title = "Text tool (Integer)"
+                description = "An integer number configuration value tool"
+                canBeDisabled = true
+                defaultEnabledValue = false
+                isCritical = true
+            },
+            "text-tool-float" to TextTool(
+                defaultValue = 3.4f,
+                hint = "Floating point number config value"
+            ).apply {
+                title = "Text tool (Floating point)"
+                description = "A floating-point number configuration value tool"
+                canBeDisabled = true
+                defaultEnabledValue = false
+                isCritical = false
+            },
+
+            "time-tool" to TimeTool(
+                days = 1,
+                hours = 2,
+                minutes = 3,
+                seconds = 4,
+                milliseconds = 5
+            ).apply {
+                title = "Time tool"
+                description = "A time configuration value tool"
+                canBeDisabled = true
+                defaultEnabledValue = false
+                isCritical = true
+            },
+
+            "enum-tool" to EnumTool(
+                defaultValueKey = "first-option",
+                allowCustom = true,
+                optionsProvider = object : EnumOptionsProvider {
+                    override fun getOptions() = mapOf(
+                        "first-option" to "First Option",
+                        "second-option" to "Second Option",
+                        "third-option" to "Third Option"
+                    )
+                }
+            ).apply {
+                title = "Enum tool"
+                description = "An enum configuration value tool"
+                canBeDisabled = true
+                defaultEnabledValue = false
+                isCritical = false
+            },
+            "enum-custom-options-provider-tool" to EnumTool(
+                defaultValueKey = "first-option",
+                allowCustom = true,
+                optionsProvider = CustomEnumOptionsProvider(
+                    fileName = "enum-options.json"
+                )
+            ).apply {
+                title = "Enum tool [Custom Provider]"
+                description = "An enum configuration value tool with a custom options provider"
+                canBeDisabled = true
+                defaultEnabledValue = false
+                isCritical = true
+            },
+
+            "tools-group" to GroupTool(
+                tools = mapOf(
+                    "toggle-tool" to ToggleTool(defaultValue = false).apply {
+                        title = "Toggle tool"
+                        description = "A boolean configuration value dev tool"
+                        canBeDisabled = true
+                        defaultEnabledValue = false
+                        isCritical = false
+                    },
+                    "text-tool" to TextTool(
+                        defaultValue = "Here can go any text value",
+                        hint = "String config value"
+                    ).apply {
+                        title = "Text tool (String)"
+                        description = "A text configuration value tool"
+                        canBeDisabled = true
+                        defaultEnabledValue = false
+                        isCritical = true
+                    },
+                    "time-tool" to TimeTool(
+                        days = 1,
+                        hours = 2,
+                        minutes = 3,
+                        seconds = 4,
+                        milliseconds = 5
+                    ).apply {
+                        title = "Time tool"
+                        description = "A time configuration value tool"
+                        canBeDisabled = true
+                        defaultEnabledValue = false
+                        isCritical = false
+                    },
+                    "enum-tool" to EnumTool(
+                        defaultValueKey = "first-option",
+                        allowCustom = true,
+                        optionsProvider = object : EnumOptionsProvider {
+                            override fun getOptions() = mapOf(
+                                "first-option" to "First Option",
+                                "second-option" to "Second Option",
+                                "third-option" to "Third Option"
+                            )
+                        }
+                    ).apply {
+                        title = "Enum tool"
+                        description = "An enum configuration value tool"
+                        canBeDisabled = true
+                        defaultEnabledValue = false
+                        isCritical = true
+                    }
+                )
+            ).apply {
+                title = "Tools group"
+            }
+        ).apply {
+            forEach { (key, value) -> value.key = key }
+        }
+}
+

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/SampleApplication.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/SampleApplication.kt
@@ -1,8 +1,19 @@
 package com.maximbircu.devtools
 
 import android.app.Application
+import com.maximbircu.devtools.MemoryDevToolsProvider.tools
+import com.maximbircu.devtools.android.readers.json
+import com.maximbircu.devtools.android.readers.yaml
+import com.maximbircu.devtools.common.DevTools
+import com.maximbircu.devtools.common.readers.DevToolsSources
+import com.maximbircu.devtools.common.readers.memory
 
 class SampleApplication : Application() {
+    lateinit var memoryDevTools: DevTools private set
+    lateinit var yamlDevTools: DevTools private set
+    lateinit var jsonDevTools: DevTools private set
+    lateinit var combinedDevTools: DevTools private set
+
     companion object {
         lateinit var application: SampleApplication
             private set
@@ -11,5 +22,14 @@ class SampleApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         application = this
+
+        val memorySource = DevToolsSources.memory(tools)
+        val ymlSource = DevToolsSources.yaml(assets, "dev-tools.yml")
+        val jsonSource = DevToolsSources.json(assets, "dev-tools.json")
+
+        memoryDevTools = DevTools.create("MEMORY", memorySource)
+        yamlDevTools = DevTools.create("YAML", ymlSource)
+        jsonDevTools = DevTools.create("JSON", jsonSource)
+        combinedDevTools = DevTools.create("COMBINED", memorySource, ymlSource, jsonSource)
     }
 }

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/CombinedSourcesConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/CombinedSourcesConfigActivity.kt
@@ -37,7 +37,7 @@ class CombinedSourcesConfigActivity : AppCompatActivity() {
         val ymlSource = DevToolsSources.yaml(assets, "dev-tools.yml")
         val jsonSource = DevToolsSources.json(assets.open("dev-tools.json").reader().readText())
 
-        devtools = DevTools.create(memorySource, ymlSource, jsonSource)
+        devtools = DevTools.create("COMBINED", memorySource, ymlSource, jsonSource)
 
         devtools.onConfigUpdated = { isCriticalUpdate ->
             val toast = Toast.makeText(
@@ -54,14 +54,14 @@ class CombinedSourcesConfigActivity : AppCompatActivity() {
 
     private fun getTools(): Map<String, DevTool<*>> {
         return mapOf(
-            "memory-toggle-tool" to ToggleTool(defaultValue = false).apply {
+            "toggle-tool" to ToggleTool(defaultValue = false).apply {
                 title = "Toggle tool"
                 description = "A boolean configuration value dev tool"
                 canBeDisabled = true
                 defaultEnabledValue = false
             },
 
-            "memory-text-tool" to TextTool(
+            "text-tool" to TextTool(
                 defaultValue = "Here can go any text value",
                 hint = "String config value"
             ).apply {
@@ -70,7 +70,7 @@ class CombinedSourcesConfigActivity : AppCompatActivity() {
                 canBeDisabled = true
                 defaultEnabledValue = false
             },
-            "memory-text-tool-integer" to TextTool(
+            "text-tool-integer" to TextTool(
                 defaultValue = 3,
                 hint = "Integer number config value"
             ).apply {
@@ -79,7 +79,7 @@ class CombinedSourcesConfigActivity : AppCompatActivity() {
                 canBeDisabled = true
                 defaultEnabledValue = false
             },
-            "memory-text-tool-float" to TextTool(
+            "text-tool-float" to TextTool(
                 defaultValue = 3.4f,
                 hint = "Floating point number config value"
             ).apply {

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/CombinedSourcesConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/CombinedSourcesConfigActivity.kt
@@ -7,20 +7,13 @@ import android.view.Gravity
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.maximbircu.devtools.R.layout
+import com.maximbircu.devtools.SampleApplication
 import com.maximbircu.devtools.android.DevToolsConfigurationScreen
-import com.maximbircu.devtools.android.readers.yaml
 import com.maximbircu.devtools.common.DevTools
-import com.maximbircu.devtools.common.core.DevTool
-import com.maximbircu.devtools.common.presentation.tools.text.TextTool
-import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
-import com.maximbircu.devtools.common.readers.DevToolsSources
-import com.maximbircu.devtools.common.readers.json
-import com.maximbircu.devtools.common.readers.memory
 import kotlinx.android.synthetic.main.activity_tools_container.devToolsContainer
 
-@Suppress("LongMethod")
 class CombinedSourcesConfigActivity : AppCompatActivity() {
-    private lateinit var devtools: DevTools
+    private val devtools: DevTools = SampleApplication.application.combinedDevTools
 
     companion object {
         fun start(context: Context) {
@@ -33,12 +26,6 @@ class CombinedSourcesConfigActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(layout.activity_tools_container)
 
-        val memorySource = DevToolsSources.memory(getTools())
-        val ymlSource = DevToolsSources.yaml(assets, "dev-tools.yml")
-        val jsonSource = DevToolsSources.json(assets.open("dev-tools.json").reader().readText())
-
-        devtools = DevTools.create("COMBINED", memorySource, ymlSource, jsonSource)
-
         devtools.onConfigUpdated = { isCriticalUpdate ->
             val toast = Toast.makeText(
                 this,
@@ -50,44 +37,5 @@ class CombinedSourcesConfigActivity : AppCompatActivity() {
         }
 
         DevToolsConfigurationScreen.attachToView(devToolsContainer, devtools)
-    }
-
-    private fun getTools(): Map<String, DevTool<*>> {
-        return mapOf(
-            "toggle-tool" to ToggleTool(defaultValue = false).apply {
-                title = "Toggle tool"
-                description = "A boolean configuration value dev tool"
-                canBeDisabled = true
-                defaultEnabledValue = false
-            },
-
-            "text-tool" to TextTool(
-                defaultValue = "Here can go any text value",
-                hint = "String config value"
-            ).apply {
-                title = "Text tool (String)"
-                description = "A text configuration value tool"
-                canBeDisabled = true
-                defaultEnabledValue = false
-            },
-            "text-tool-integer" to TextTool(
-                defaultValue = 3,
-                hint = "Integer number config value"
-            ).apply {
-                title = "Text tool (Integer)"
-                description = "An integer number configuration value tool"
-                canBeDisabled = true
-                defaultEnabledValue = false
-            },
-            "text-tool-float" to TextTool(
-                defaultValue = 3.4f,
-                hint = "Floating point number config value"
-            ).apply {
-                title = "Text tool (Floating point)"
-                description = "A floating-point number configuration value tool"
-                canBeDisabled = true
-                defaultEnabledValue = false
-            }
-        )
     }
 }

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/JsonSchemaSourceConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/JsonSchemaSourceConfigActivity.kt
@@ -29,7 +29,7 @@ class JsonSchemaSourceConfigActivity : AppCompatActivity() {
         setContentView(layout.activity_tools_container)
 
         val source = DevToolsSources.json(assets.open("dev-tools.json").reader().readText())
-        devtools = DevTools.create(source)
+        devtools = DevTools.create("JSON", source)
 
         devtools.onConfigUpdated = { isCriticalUpdate ->
             val toast = Toast.makeText(

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/JsonSchemaSourceConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/JsonSchemaSourceConfigActivity.kt
@@ -7,15 +7,13 @@ import android.view.Gravity
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.maximbircu.devtools.R.layout
+import com.maximbircu.devtools.SampleApplication
 import com.maximbircu.devtools.android.DevToolsConfigurationScreen
 import com.maximbircu.devtools.common.DevTools
-import com.maximbircu.devtools.common.readers.DevToolsSources
-import com.maximbircu.devtools.common.readers.json
 import kotlinx.android.synthetic.main.activity_tools_container.devToolsContainer
 
-@Suppress("LongMethod")
 class JsonSchemaSourceConfigActivity : AppCompatActivity() {
-    private lateinit var devtools: DevTools
+    private val devtools: DevTools = SampleApplication.application.jsonDevTools
 
     companion object {
         fun start(context: Context) {
@@ -27,9 +25,6 @@ class JsonSchemaSourceConfigActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(layout.activity_tools_container)
-
-        val source = DevToolsSources.json(assets.open("dev-tools.json").reader().readText())
-        devtools = DevTools.create("JSON", source)
 
         devtools.onConfigUpdated = { isCriticalUpdate ->
             val toast = Toast.makeText(

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/MemorySourceConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/MemorySourceConfigActivity.kt
@@ -37,7 +37,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
         setContentView(layout.activity_tools_container)
 
         val source = DevToolsSources.memory(getTools())
-        devtools = DevTools.create(source)
+        devtools = DevTools.create("MEMORY", source)
 
         devtools.onConfigUpdated = { isCriticalUpdate ->
             val toast = Toast.makeText(
@@ -54,7 +54,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
 
     private fun getTools(): Map<String, DevTool<*>> {
         return mapOf(
-            "memory-toggle-tool" to ToggleTool(defaultValue = false).apply {
+            "toggle-tool" to ToggleTool(defaultValue = false).apply {
                 title = "Toggle tool"
                 description = "A boolean configuration value dev tool"
                 canBeDisabled = true
@@ -62,7 +62,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 isCritical = true
             },
 
-            "memory-text-tool" to TextTool(
+            "text-tool" to TextTool(
                 defaultValue = "Here can go any text value",
                 hint = "String config value"
             ).apply {
@@ -72,7 +72,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 defaultEnabledValue = false
                 isCritical = false
             },
-            "memory-text-tool-integer" to TextTool(
+            "text-tool-integer" to TextTool(
                 defaultValue = 3,
                 hint = "Integer number config value"
             ).apply {
@@ -82,7 +82,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 defaultEnabledValue = false
                 isCritical = true
             },
-            "memory-text-tool-float" to TextTool(
+            "text-tool-float" to TextTool(
                 defaultValue = 3.4f,
                 hint = "Floating point number config value"
             ).apply {
@@ -93,7 +93,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 isCritical = false
             },
 
-            "memory-time-tool" to TimeTool(
+            "time-tool" to TimeTool(
                 days = 1,
                 hours = 2,
                 minutes = 3,
@@ -107,7 +107,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 isCritical = true
             },
 
-            "memory-enum-tool" to EnumTool(
+            "enum-tool" to EnumTool(
                 defaultValueKey = "first-option",
                 allowCustom = true,
                 optionsProvider = object : EnumOptionsProvider {
@@ -124,7 +124,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 defaultEnabledValue = false
                 isCritical = false
             },
-            "memory-enum-custom-options-provider-tool" to EnumTool(
+            "enum-custom-options-provider-tool" to EnumTool(
                 defaultValueKey = "first-option",
                 allowCustom = true,
                 optionsProvider = CustomEnumOptionsProvider(
@@ -138,16 +138,16 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                 isCritical = true
             },
 
-            "memory-tools-group" to GroupTool(
+            "tools-group" to GroupTool(
                 tools = mapOf(
-                    "memory-toggle-tool" to ToggleTool(defaultValue = false).apply {
+                    "toggle-tool" to ToggleTool(defaultValue = false).apply {
                         title = "Toggle tool"
                         description = "A boolean configuration value dev tool"
                         canBeDisabled = true
                         defaultEnabledValue = false
                         isCritical = false
                     },
-                    "memory-text-tool" to TextTool(
+                    "text-tool" to TextTool(
                         defaultValue = "Here can go any text value",
                         hint = "String config value"
                     ).apply {
@@ -157,7 +157,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                         defaultEnabledValue = false
                         isCritical = true
                     },
-                    "memory-time-tool" to TimeTool(
+                    "time-tool" to TimeTool(
                         days = 1,
                         hours = 2,
                         minutes = 3,
@@ -170,7 +170,7 @@ class MemorySourceConfigActivity : AppCompatActivity() {
                         defaultEnabledValue = false
                         isCritical = false
                     },
-                    "memory-enum-tool" to EnumTool(
+                    "enum-tool" to EnumTool(
                         defaultValueKey = "first-option",
                         allowCustom = true,
                         optionsProvider = object : EnumOptionsProvider {

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/MemorySourceConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/MemorySourceConfigActivity.kt
@@ -6,24 +6,14 @@ import android.os.Bundle
 import android.view.Gravity
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import com.maximbircu.devtools.CustomEnumOptionsProvider
 import com.maximbircu.devtools.R.layout
+import com.maximbircu.devtools.SampleApplication
 import com.maximbircu.devtools.android.DevToolsConfigurationScreen
 import com.maximbircu.devtools.common.DevTools
-import com.maximbircu.devtools.common.core.DevTool
-import com.maximbircu.devtools.common.presentation.tools.enum.EnumOptionsProvider
-import com.maximbircu.devtools.common.presentation.tools.enum.EnumTool
-import com.maximbircu.devtools.common.presentation.tools.group.GroupTool
-import com.maximbircu.devtools.common.presentation.tools.text.TextTool
-import com.maximbircu.devtools.common.presentation.tools.time.TimeTool
-import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
-import com.maximbircu.devtools.common.readers.DevToolsSources
-import com.maximbircu.devtools.common.readers.memory
 import kotlinx.android.synthetic.main.activity_tools_container.devToolsContainer
 
-@Suppress("LongMethod", "ComplexMethod", "LargeClass")
 class MemorySourceConfigActivity : AppCompatActivity() {
-    private lateinit var devtools: DevTools
+    private val devtools: DevTools = SampleApplication.application.memoryDevTools
 
     companion object {
         fun start(context: Context) {
@@ -36,9 +26,6 @@ class MemorySourceConfigActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(layout.activity_tools_container)
 
-        val source = DevToolsSources.memory(getTools())
-        devtools = DevTools.create("MEMORY", source)
-
         devtools.onConfigUpdated = { isCriticalUpdate ->
             val toast = Toast.makeText(
                 this,
@@ -50,149 +37,5 @@ class MemorySourceConfigActivity : AppCompatActivity() {
         }
 
         DevToolsConfigurationScreen.attachToView(devToolsContainer, devtools)
-    }
-
-    private fun getTools(): Map<String, DevTool<*>> {
-        return mapOf(
-            "toggle-tool" to ToggleTool(defaultValue = false).apply {
-                title = "Toggle tool"
-                description = "A boolean configuration value dev tool"
-                canBeDisabled = true
-                defaultEnabledValue = false
-                isCritical = true
-            },
-
-            "text-tool" to TextTool(
-                defaultValue = "Here can go any text value",
-                hint = "String config value"
-            ).apply {
-                title = "Text tool (String)"
-                description = "A text configuration value tool"
-                canBeDisabled = true
-                defaultEnabledValue = false
-                isCritical = false
-            },
-            "text-tool-integer" to TextTool(
-                defaultValue = 3,
-                hint = "Integer number config value"
-            ).apply {
-                title = "Text tool (Integer)"
-                description = "An integer number configuration value tool"
-                canBeDisabled = true
-                defaultEnabledValue = false
-                isCritical = true
-            },
-            "text-tool-float" to TextTool(
-                defaultValue = 3.4f,
-                hint = "Floating point number config value"
-            ).apply {
-                title = "Text tool (Floating point)"
-                description = "A floating-point number configuration value tool"
-                canBeDisabled = true
-                defaultEnabledValue = false
-                isCritical = false
-            },
-
-            "time-tool" to TimeTool(
-                days = 1,
-                hours = 2,
-                minutes = 3,
-                seconds = 4,
-                milliseconds = 5
-            ).apply {
-                title = "Time tool"
-                description = "A time configuration value tool"
-                canBeDisabled = true
-                defaultEnabledValue = false
-                isCritical = true
-            },
-
-            "enum-tool" to EnumTool(
-                defaultValueKey = "first-option",
-                allowCustom = true,
-                optionsProvider = object : EnumOptionsProvider {
-                    override fun getOptions() = mapOf(
-                        "first-option" to "First Option",
-                        "second-option" to "Second Option",
-                        "third-option" to "Third Option"
-                    )
-                }
-            ).apply {
-                title = "Enum tool"
-                description = "An enum configuration value tool"
-                canBeDisabled = true
-                defaultEnabledValue = false
-                isCritical = false
-            },
-            "enum-custom-options-provider-tool" to EnumTool(
-                defaultValueKey = "first-option",
-                allowCustom = true,
-                optionsProvider = CustomEnumOptionsProvider(
-                    fileName = "enum-options.json"
-                )
-            ).apply {
-                title = "Enum tool [Custom Provider]"
-                description = "An enum configuration value tool with a custom options provider"
-                canBeDisabled = true
-                defaultEnabledValue = false
-                isCritical = true
-            },
-
-            "tools-group" to GroupTool(
-                tools = mapOf(
-                    "toggle-tool" to ToggleTool(defaultValue = false).apply {
-                        title = "Toggle tool"
-                        description = "A boolean configuration value dev tool"
-                        canBeDisabled = true
-                        defaultEnabledValue = false
-                        isCritical = false
-                    },
-                    "text-tool" to TextTool(
-                        defaultValue = "Here can go any text value",
-                        hint = "String config value"
-                    ).apply {
-                        title = "Text tool (String)"
-                        description = "A text configuration value tool"
-                        canBeDisabled = true
-                        defaultEnabledValue = false
-                        isCritical = true
-                    },
-                    "time-tool" to TimeTool(
-                        days = 1,
-                        hours = 2,
-                        minutes = 3,
-                        seconds = 4,
-                        milliseconds = 5
-                    ).apply {
-                        title = "Time tool"
-                        description = "A time configuration value tool"
-                        canBeDisabled = true
-                        defaultEnabledValue = false
-                        isCritical = false
-                    },
-                    "enum-tool" to EnumTool(
-                        defaultValueKey = "first-option",
-                        allowCustom = true,
-                        optionsProvider = object : EnumOptionsProvider {
-                            override fun getOptions() = mapOf(
-                                "first-option" to "First Option",
-                                "second-option" to "Second Option",
-                                "third-option" to "Third Option"
-                            )
-                        }
-                    ).apply {
-                        title = "Enum tool"
-                        description = "An enum configuration value tool"
-                        canBeDisabled = true
-                        defaultEnabledValue = false
-                        isCritical = true
-                    }
-                )
-            ).apply {
-                title = "Tools group"
-            }
-        ).apply {
-            forEach { (key, value) -> value.key = key }
-        }
     }
 }

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/YamlSourceConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/YamlSourceConfigActivity.kt
@@ -7,15 +7,12 @@ import android.view.Gravity
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.maximbircu.devtools.R.layout
+import com.maximbircu.devtools.SampleApplication
 import com.maximbircu.devtools.android.DevToolsConfigurationScreen
-import com.maximbircu.devtools.android.readers.yaml
-import com.maximbircu.devtools.common.DevTools
-import com.maximbircu.devtools.common.readers.DevToolsSources
 import kotlinx.android.synthetic.main.activity_tools_container.devToolsContainer
 
-@Suppress("LongMethod")
 class YamlSourceConfigActivity : AppCompatActivity() {
-    private lateinit var devtools: DevTools
+    private val devtools = SampleApplication.application.yamlDevTools
 
     companion object {
         fun start(context: Context) {
@@ -27,9 +24,6 @@ class YamlSourceConfigActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(layout.activity_tools_container)
-
-        val source = DevToolsSources.yaml(assets, "dev-tools.yml")
-        devtools = DevTools.create("YAML", source)
 
         devtools.onConfigUpdated = { isCriticalUpdate ->
             val toast = Toast.makeText(

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/YamlSourceConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/YamlSourceConfigActivity.kt
@@ -29,7 +29,7 @@ class YamlSourceConfigActivity : AppCompatActivity() {
         setContentView(layout.activity_tools_container)
 
         val source = DevToolsSources.yaml(assets, "dev-tools.yml")
-        devtools = DevTools.create(source)
+        devtools = DevTools.create("YAML", source)
 
         devtools.onConfigUpdated = { isCriticalUpdate ->
             val toast = Toast.makeText(


### PR DESCRIPTION
Closes: <!-- Add a link to the issue this PR relates to -->

- [x] Unit tests  <!-- Check this if you covered your code with unit tests -->
- [x] Changelog <!-- Check this if you updated the changelog file  -->
- [x] Documentation (Readme) <!-- Check this if you updated the  documentation  -->

### What has been done
1 Add `DevTools#updateFromParams` which allows the library consumer to update the tools from a set of params(key-value pairs)
1 Add `DevTools#updateFromBundle` which allows the Android library consumer to update the tools from an Android bundle
1 Made each `DevTools` instance use a different storage key so that the similar tools don't collide

### How to test
1.  Open the sample app passing `--ez toggle-tool true --ez tools-group.toggle-tool true ` as startup arguments;
2. Make sure the changes are applied.
