### PR TITLE
Add library API documentation

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -97,7 +97,7 @@ jobs:
           xcodebuild clean test \
             -workspace DevtoolsFramework.xcworkspace \
             -scheme DevtoolsFramework \
-            -destination 'platform=iOS Simulator,OS=13.3,name=iPhone 11 Pro'
+            -destination 'platform=iOS Simulator,name=iPhone 11 Pro'
 
   build:
     name: Assemble artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ Changelog
 =========
 
 ## Version 1.0.0 *(In development)*
+Issue: [#40](https://github.com/maximbircu/devtools-library/issues/40)
+- Cover the whole library with documentation, check README;
+- Add library extension Android samples;
+- Remove redundant yml- prefix;
+- Replace defaultValue with default everywhere to make the API consistent.
+
 Issue: [#39](https://github.com/maximbircu/devtools-library/issues/39)
 - Add `DevTools#updateFromParams` which allows the library consumer to update the tools from a set of params(key-value pairs)
 - Add `DevTools#updateFromBundle` which allows the Android library consumer to update the tools from an Android bundle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contribution rules:
+# 👷 Contribution rules:
 1. Make sure there is a GitHub issue describing the changes you want to contribute with. (Add one if needed)
 2. Submit a PR just in case you:
   - Fixed the bug or implement the new feature properly;

--- a/README.md
+++ b/README.md
@@ -1,15 +1,37 @@
+<img width="270" align="right" alt="dev-tools" src="https://user-images.githubusercontent.com/12527390/80514191-daf0e780-8988-11ea-911f-15d16e6b88a1.png"/>
+
 ![Platform](https://img.shields.io/badge/platform-Android%20%7C%20iOS-lightgrey?style=flat)
 
 ![CI](https://github.com/maximbircu/devtools-library/workflows/CI/badge.svg?branch=master)
 [![codecov](https://codecov.io/gh/maximbircu/devtools-library/branch/master/graph/badge.svg?token=TP8XUCW2HB)](https://codecov.io/gh/maximbircu/devtools-library)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/maximbircu/devtools-library/blob/master/LICENSE.md)
+
 # Devtools
 
-Devtools is a pluggable, extensible, and dynamic config library that supports YAML or JSON as a source.
+#### 🚀 [Quick Start](documentation/quickstart/quick-start.md)
+#### 📜 [Full Documentation](documentation/documentation.md)
+#### 👷 [For Developers](documentation/documentation.md/#for-developers)
 
-It helps to manipulate (persist, update, and use in the app) different configuration values for any android application.
+Devtools is a pluggable, extensible, and dynamic config library that supports [YAML](https://yaml.org/) and [JSON Schema Draft-07](https://json-schema.org/draft-07/json-schema-validation.html) as configuration sources.
 
-# For developers
-If you know how to fix an issue, consider opening a pull request for it.
+It helps to manipulate (persist, update, and use in the app) different configuration values for any mobile application.
 
-You can read this repository’s [contributing guidelines](CONTRIBUTING.md) to learn how to open a good pull request.
+After you integrate the library and provide it a YML or JSON Schema configuration file, you'll be able to update your configuration values through a nice configuration user interface screen that the library will generate dynamically, using startup arguments or directly from the code.
+
+  
+License
+-------
+
+    Copyright 2020 Maxim Bîrcu
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 
 # Devtools
 
-#### 🚀 [Quick Start](documentation/quickstart/quick-start.md)
-#### 📜 [Full Documentation](documentation/documentation.md)
-#### 👷 [For Developers](documentation/documentation.md/#for-developers)
+#### 🚀 [Quick Start](documentation/quickstart/quick-start.md) &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; [🍏 iOS Sample](samples/ios)</div>
+#### 📜 [Documentation](documentation/documentation.md) &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; [🤖 Android Sample](samples/android) 
+#### 👷 [For Developers](documentation/documentation.md#-for-developers)
+
+<br />
 
 Devtools is a pluggable, extensible, and dynamic config library that supports [YAML](https://yaml.org/) and [JSON Schema Draft-07](https://json-schema.org/draft-07/json-schema-validation.html) as configuration sources.
 

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/text/TextTool.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/text/TextTool.kt
@@ -6,11 +6,11 @@ import kotlin.reflect.KClass
 /**
  * Represents a dev tool able to manipulate text and numbers configuration values.
  *
- * @property defaultValue the default text or number configuration value
+ * @property default the default text or number configuration value
  * @property hint the text which aims to add more context about the purpose of the config value
  */
 data class TextTool(
-    private val defaultValue: Any? = null,
+    private val default: Any? = null,
     val hint: String? = null
 ) : PreferencesDevTool<Any>() {
     private val supportedTypes = setOf(
@@ -28,7 +28,7 @@ data class TextTool(
     val configValueType: KClass<*> get() = getDefaultValue()::class
 
     override fun getDefaultValue(): Any {
-        val value = defaultValue ?: throw NullPointerException("Default val required")
+        val value = default ?: throw NullPointerException("Default val required")
         assertTypeSupported(value::class)
         return value
     }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/toggle/ToggleTool.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/toggle/ToggleTool.kt
@@ -5,10 +5,10 @@ import com.maximbircu.devtools.common.core.PreferencesDevTool
 /**
  * Represents a dev tool able to manipulate boolean configuration values.
  *
- * @property defaultValue the default boolean configuration value
+ * @property default the default boolean configuration value
  */
 data class ToggleTool(
-    private val defaultValue: Boolean = false
+    private val default: Boolean = false
 ) : PreferencesDevTool<Boolean>() {
-    override fun getDefaultValue(): Boolean = defaultValue
+    override fun getDefaultValue(): Boolean = default
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/core/DevToolTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/core/DevToolTest.kt
@@ -28,7 +28,7 @@ class DevToolTest : BaseTest() {
     @Test
     fun `resets the tool state to proper default values`() {
         val devTool = createDevTool(
-            defaultValue = "Default configuration value",
+            default = "Default configuration value",
             defaultEnabledValue = true
         )
         devTool.value = "Some custom value"
@@ -126,13 +126,13 @@ class DevToolTest : BaseTest() {
 
     private fun createDevTool(
         store: ToolStore<String> = this.store,
-        defaultValue: String = "",
+        default: String = "",
         defaultEnabledValue: Boolean = true
     ): DevTool<String> {
         return object : DevTool<String>(defaultEnabledValue = defaultEnabledValue) {
             override val store: ToolStore<String> = store
 
-            override fun getDefaultValue() = defaultValue
+            override fun getDefaultValue() = default
         }
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/text/TextToolTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/text/TextToolTest.kt
@@ -8,14 +8,14 @@ import kotlin.test.assertFailsWith
 class TextToolTest : BaseTest() {
     @Test
     fun `returns proper default value`() {
-        val tool = TextTool(defaultValue = 3)
+        val tool = TextTool(default = 3)
 
         assertEquals(3, tool.getDefaultValue())
     }
 
     @Test
     fun `returns proper hint value`() {
-        val tool = TextTool(defaultValue = 3, hint = "hint value")
+        val tool = TextTool(default = 3, hint = "hint value")
 
         assertEquals("hint value", tool.hint)
     }
@@ -29,14 +29,14 @@ class TextToolTest : BaseTest() {
 
     @Test
     fun `throws exception if provided value type is not supported`() {
-        val tool = TextTool(defaultValue = object {})
+        val tool = TextTool(default = object {})
 
         assertFailsWith<IllegalArgumentException> { tool.getDefaultValue() }
     }
 
     @Test
     fun `returns proper data type`() {
-        val tool = TextTool(defaultValue = "text value")
+        val tool = TextTool(default = "text value")
 
         assertEquals(String::class, tool.configValueType)
     }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/toggle/ToggleToolTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/toggle/ToggleToolTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertTrue
 class ToggleToolTest : BaseTest() {
     @Test
     fun `returns proper default value`() {
-        val tool = ToggleTool(defaultValue = true)
+        val tool = ToggleTool(default = true)
 
         assertTrue(tool.getDefaultValue())
     }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaReaderTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaReaderTest.kt
@@ -13,8 +13,8 @@ class JsonSchemaReaderTest : BaseTest() {
         val config = getConfig()
         val reader = JsonSchemaReader(config)
         val expectedTools = mapOf<String, DevTool<*>>(
-            "json-schema-toggle-tool" to ToggleTool(defaultValue = true),
-            "json-schema-text-tool" to TextTool(defaultValue = "String config value")
+            "json-schema-toggle-tool" to ToggleTool(default = true),
+            "json-schema-text-tool" to TextTool(default = "String config value")
         )
 
         val actualTools = reader.getDevTools()

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolDoubleFactoryTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolDoubleFactoryTest.kt
@@ -10,7 +10,7 @@ class JsonSchemaTextToolDoubleFactoryTest : BaseTest() {
     @Test
     fun `creates a proper text tool without default and hint values provided`() {
         val jsonObject = json {}
-        val expectedTool = TextTool(defaultValue = 0.0)
+        val expectedTool = TextTool(default = 0.0)
         val factory = JsonSchemaTextToolDoubleFactory(jsonObject)
 
         val actualTool = factory.create()
@@ -23,7 +23,7 @@ class JsonSchemaTextToolDoubleFactoryTest : BaseTest() {
         val jsonObject = json {
             "default" to 3.4
         }
-        val expectedTool = TextTool(defaultValue = 3.4)
+        val expectedTool = TextTool(default = 3.4)
         val factory = JsonSchemaTextToolDoubleFactory(jsonObject)
 
         val actualTool = factory.create()
@@ -37,7 +37,7 @@ class JsonSchemaTextToolDoubleFactoryTest : BaseTest() {
             "hint" to "Floating point number config value"
         }
         val expectedTool = TextTool(
-            defaultValue = 0.0,
+            default = 0.0,
             hint = "Floating point number config value"
         )
         val factory = JsonSchemaTextToolDoubleFactory(jsonObject)
@@ -54,7 +54,7 @@ class JsonSchemaTextToolDoubleFactoryTest : BaseTest() {
             "hint" to "Floating point number config value"
         }
         val expectedTool = TextTool(
-            defaultValue = 3.4,
+            default = 3.4,
             hint = "Floating point number config value"
         )
         val factory = JsonSchemaTextToolDoubleFactory(jsonObject)

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolFactoryTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolFactoryTest.kt
@@ -10,7 +10,7 @@ class JsonSchemaTextToolFactoryTest : BaseTest() {
     @Test
     fun `creates a proper text tool without default and hint values provided`() {
         val jsonObject = json {}
-        val expectedTool = TextTool(defaultValue = "")
+        val expectedTool = TextTool(default = "")
         val factory = JsonSchemaTextToolFactory(jsonObject)
 
         val actualTool = factory.create()
@@ -23,7 +23,7 @@ class JsonSchemaTextToolFactoryTest : BaseTest() {
         val jsonObject = json {
             "default" to "String config value"
         }
-        val expectedTool = TextTool(defaultValue = "String config value")
+        val expectedTool = TextTool(default = "String config value")
         val factory = JsonSchemaTextToolFactory(jsonObject)
 
         val actualTool = factory.create()
@@ -37,7 +37,7 @@ class JsonSchemaTextToolFactoryTest : BaseTest() {
             "hint" to "Floating point number config value"
         }
         val expectedTool = TextTool(
-            defaultValue = "",
+            default = "",
             hint = "Floating point number config value"
         )
         val factory = JsonSchemaTextToolFactory(jsonObject)
@@ -54,7 +54,7 @@ class JsonSchemaTextToolFactoryTest : BaseTest() {
             "hint" to "Floating point number config value"
         }
         val expectedTool = TextTool(
-            defaultValue = "String config value",
+            default = "String config value",
             hint = "Floating point number config value"
         )
         val factory = JsonSchemaTextToolFactory(jsonObject)

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolIntegerFactoryTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolIntegerFactoryTest.kt
@@ -10,7 +10,7 @@ class JsonSchemaTextToolIntegerFactoryTest : BaseTest() {
     @Test
     fun `creates a proper text tool without default and hint values provided`() {
         val jsonObject = json {}
-        val expectedTool = TextTool(defaultValue = 0)
+        val expectedTool = TextTool(default = 0)
         val factory = JsonSchemaTextToolIntegerFactory(jsonObject)
 
         val actualTool = factory.create()
@@ -23,7 +23,7 @@ class JsonSchemaTextToolIntegerFactoryTest : BaseTest() {
         val jsonObject = json {
             "default" to 3
         }
-        val expectedTool = TextTool(defaultValue = 3)
+        val expectedTool = TextTool(default = 3)
         val factory = JsonSchemaTextToolIntegerFactory(jsonObject)
 
         val actualTool = factory.create()
@@ -37,7 +37,7 @@ class JsonSchemaTextToolIntegerFactoryTest : BaseTest() {
             "hint" to "Floating point number config value"
         }
         val expectedTool = TextTool(
-            defaultValue = 0,
+            default = 0,
             hint = "Floating point number config value"
         )
         val factory = JsonSchemaTextToolIntegerFactory(jsonObject)
@@ -54,7 +54,7 @@ class JsonSchemaTextToolIntegerFactoryTest : BaseTest() {
             "hint" to "Floating point number config value"
         }
         val expectedTool = TextTool(
-            defaultValue = 3,
+            default = 3,
             hint = "Floating point number config value"
         )
         val factory = JsonSchemaTextToolIntegerFactory(jsonObject)

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaToggleToolFactoryTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaToggleToolFactoryTest.kt
@@ -21,7 +21,7 @@ class JsonSchemaToggleToolFactoryTest : BaseTest() {
     @Test
     fun `creates a proper enum dev tool with default value provided`() {
         val jsonObject = json { "default" to true }
-        val expectedTool = ToggleTool(defaultValue = true)
+        val expectedTool = ToggleTool(default = true)
         val factory = JsonSchemaToggleToolFactory(jsonObject)
 
         val actualTool = factory.create()

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/sources/JsonSchemaSourceTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/sources/JsonSchemaSourceTest.kt
@@ -22,8 +22,8 @@ class JsonSchemaSourceTest : BaseTest() {
         val config = getConfig()
         val source = JsonSchemaSource(config)
         val expectedTools = mapOf<String, DevTool<*>>(
-            "json-schema-toggle-tool" to ToggleTool(defaultValue = true),
-            "json-schema-text-tool" to TextTool(defaultValue = "String config value")
+            "json-schema-toggle-tool" to ToggleTool(default = true),
+            "json-schema-text-tool" to TextTool(default = "String config value")
         )
 
         val actualTools = source.getReader().getDevTools()

--- a/documentation/configscreen/android-config-screen.md
+++ b/documentation/configscreen/android-config-screen.md
@@ -1,0 +1,22 @@
+[<img width="90" align="right" src="https://user-images.githubusercontent.com/12527390/80737506-4ae3a700-8b1c-11ea-92b7-a137982595ea.png"/>](#)
+
+# Configuration screen
+One of the easiest ways to update a configuration value will be an excellent user interface. The library is able to generate a configuration screen dynamically based on your configuration file.
+
+## How to use
+To show the screen, you just need to create a new activity for it and attach it to any view, as shown in the sample below.
+
+```Kotlin
+class DevToolsActivity: AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val contentView = findViewById<ViewGroup>(android.R.id.content)
+        DevToolsConfigurationScreen.attachToView(contentView, MyApplication.application.devtools)
+    }
+}
+```
+You can attach this config screen view to any other view from your app.
+
+## Theming
+The android library is based on material design. There is a [Theme.DevTools](../../devtools/android/src/main/res/values/styles.xml#L3) that you might extend inside your app to update the colors, text appearance, and shaping.

--- a/documentation/configscreen/ios-config-screen.md
+++ b/documentation/configscreen/ios-config-screen.md
@@ -1,0 +1,17 @@
+[<img width="90" align="right" src="https://user-images.githubusercontent.com/12527390/80737507-4c14d400-8b1c-11ea-9b82-d44718783a2e.png"/>](#)
+
+# Configuration screen
+ 
+<br/> <br/> <br/> 
+<div align="center"><img alt="work in progress" src="https://user-images.githubusercontent.com/12527390/80824719-b0e93080-8be7-11ea-8be4-8294a6652cb8.png" /></div>
+<br/> <br/> <br/> <br/>
+
+The iOS library is not ready yet. 😞
+
+## 👷 For Developers
+
+Consider opening a pull request to accelerate its release. 🙏
+
+Check out the remaining work till the first release [here](https://github.com/maximbircu/devtools-library/issues?q=is%3Aopen+is%3Aissue+label%3AiOS).
+
+You can read this repository’s [contributing guidelines](../CONTRIBUTING.md) to learn how to open a good pull request.

--- a/documentation/customtools/custom-tools-android.md
+++ b/documentation/customtools/custom-tools-android.md
@@ -1,0 +1,130 @@
+[<img width="90" align="right" src="https://user-images.githubusercontent.com/12527390/80737506-4ae3a700-8b1c-11ea-92b7-a137982595ea.png"/>](#)
+
+# 👷 Custom dev tool types
+
+In case the prebuilt tools set is not sufficient, or you don't like the UX they provided, you might build your own inside your app. 
+The process is straightforward, you just need to extend a couple of classes and implement your custom logic inside them. 
+Let's see how to do it in a simple step by step example:
+
+1. **Define the configuration value type**
+
+   So, first of all, you need to understand what's the type of configuration value that your new dev tool will wrap and manipulate. Let's say it will be `Boolean` just for the sake of example.
+
+1. **Create a domain object**
+
+    To create a domain object you should extend the [DevTool](../../devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt) class and provide a default value and a store implementation.
+    
+    Creating a custom store is not difficult, check [custom store](#custom-dev-tools-store) for more information.
+    
+    However to make the example simpler I'll extend the [PreferencesDevTool](../../devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/DevTool.kt#L116) which comes with a built-in `SharedPreferences` store. 
+
+    ```kotlin
+    class MyCustomTool : PreferencesDevTool<Boolean>() {
+        override fun getDefaultValue(): Boolean {
+            return true // Suppose that I want the default value to always be true.
+        }
+    }
+    ```
+
+2. **Create a UI component**
+
+    To do this, you just need to extend the [DevToolLayout](../../devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tool/DevToolLayout.kt) and provide my custom dev tool user interface implementation. 
+
+    ```kotlin
+    class MyCustomToolLayout(context: Context) : DevToolLayout<MyCustomTool>(context) {
+        override val layoutRes: Int get() = layout.layout_my_custom_tool
+    
+        override fun onBind(tool: MyCustomTool) {
+            checkbox.isChecked = tool.value
+            checkbox.setOnCheckedChangeListener { _, isChecked -> tool.value = isChecked }
+        }
+    }
+    ```
+
+    And here is the `layout_my_custom_tool.xml`. The XML layout for this custom view. It will contain a checkbox so that we can change a boolean configuration value.
+    
+    ```xml
+    <?xml version="1.0" encoding="utf-8"?>
+    <CheckBox xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Is checked"
+        />
+    ```
+
+3. **Register your new dev tool (tell the library that your dev tool-type exists)** 
+
+    To do this, you'll have to call one line at the app start. 
+    ```kotlin
+    DevToolsViewRegistry.register(MyCustomTool::class) { MyCustomToolLayout(it) }
+    ```
+    ⚠️ You cannot register the same tool twice, you have to call this line just one time per Application scope.
+    I am calling it inside the Application `onCreate` method.
+    
+4. **Create a custom tools source**
+    
+    In order to use your custom tool, you'll need to create a custom source to be able to provide its instance to the library.
+
+    ```kotlin
+     val myCustomToolSource = object :DevToolsSource {
+        override fun getReader(): DevToolsReader {
+            return object: DevToolsReader {
+                override fun getDevTools(): Map<String, DevTool<*>> {
+                    return mapOf(
+                        "my-custom-tool" to MyCustomTool().apply {
+                            title = "Custom dev tool"
+                            description = "A custom dev tool implemented inside the library consumer"
+                            canBeDisabled = true
+                            defaultEnabledValue = false
+                        }
+                    )
+                }
+            }
+    
+        }
+    }
+    ```
+5. **And finally** 🎉
+
+    Use your tool inside any dev tools instance
+    ```Kotlin
+    val tools = DevTools.create("MY_CUSTOM_TOOLS", myCustomToolSource)
+    ```
+   
+### Custom dev tools store
+
+All the library prebuilt dev tools are using a SharedPreferences store. However, you can create your own stores and use them inside your custom tools.
+
+You just have to extend [ToolStore](../../devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/ToolStore.kt) and provide your own implementation.
+
+Here is an example of a custom store that also saves the data to shared preferences.
+
+```kotlin
+private val sharedPrefs = SampleApplication.application.getSharedPreferences(
+    "MY_CUSTOM_TOOL_STORE",
+    Context.MODE_PRIVATE
+)
+
+class MyCustomToolStore(private val tool: MyCustomTool): ToolStore<Boolean> {
+    override var isEnabled: Boolean
+        get() = sharedPrefs.getBoolean("is_enabled_${tool.key}", tool.defaultEnabledValue)
+        set(value) { sharedPrefs.edit().putBoolean("is_enabled_${tool.key}", value).commit() }
+
+    override var value: Boolean
+        get() = sharedPrefs.getBoolean(tool.key, tool.getDefaultValue())
+        set(value) { sharedPrefs.edit().putBoolean(tool.key, value).commit() }
+}
+```
+
+And this is how you can use your store.
+
+```kotlin
+class MyCustomTool : DevTool<Boolean>() {
+    override val store: ToolStore<Boolean> = MyCustomToolStore(this)
+
+    override fun getDefaultValue(): Boolean {
+        return false // Suppose that I want the default value to always be true.
+    }
+}
+```

--- a/documentation/customtools/custom-tools-android.md
+++ b/documentation/customtools/custom-tools-android.md
@@ -73,7 +73,7 @@ Let's see how to do it in a simple step by step example:
                 override fun getDevTools(): Map<String, DevTool<*>> {
                     return mapOf(
                         "my-custom-tool" to MyCustomTool().apply {
-                            title = "Custom dev tool"
+                            title = "Custom tool"
                             description = "A custom dev tool implemented inside the library consumer"
                             canBeDisabled = true
                             defaultEnabledValue = false

--- a/documentation/customtools/custom-tools-ios.md
+++ b/documentation/customtools/custom-tools-ios.md
@@ -1,0 +1,17 @@
+[<img width="90" align="right" src="https://user-images.githubusercontent.com/12527390/80737507-4c14d400-8b1c-11ea-9b82-d44718783a2e.png"/>](#)
+
+# 👷 Custom dev tool types
+ 
+<br/> <br/> <br/> 
+<div align="center"><img alt="work in progress" src="https://user-images.githubusercontent.com/12527390/80824719-b0e93080-8be7-11ea-8be4-8294a6652cb8.png" /></div>
+<br/> <br/> <br/> <br/>
+
+The iOS library is not ready yet. 😞
+
+## 👷 For Developers
+
+Consider opening a pull request to accelerate its release. 🙏
+
+Check out the remaining work till the first release [here](https://github.com/maximbircu/devtools-library/issues?q=is%3Aopen+is%3Aissue+label%3AiOS).
+
+You can read this repository’s [contributing guidelines](../CONTRIBUTING.md) to learn how to open a good pull request.

--- a/documentation/documentation.md
+++ b/documentation/documentation.md
@@ -1,0 +1,384 @@
+# Documentation
+
+<img width="400" align="right" alt="dev-tools" src="https://user-images.githubusercontent.com/12527390/80514191-daf0e780-8988-11ea-911f-15d16e6b88a1.png"/>
+
+* [🚀 Quick start](quickstart/quick-start.md) 
+    * [🍏 iOS](quickstart/quick-start-ios.md) 
+    * [🤖 Android](quickstart/quick-start-android.md) 
+* [Prebuilt dev tool types](#prebuilt-dev-tool-types)
+* 👷 [Custom dev tool types](#-custom-dev-tool-types)
+    * [🍏 iOS](customtools/custom-tools-ios.md)
+    * [🤖 Android](customtools/custom-tools-android.md)
+* [Configuration sources](#configuration-sources)
+    * [Prebuilt sources](#prebuilt-sources)
+    * 👷 [Custom sources](#-custom-sources)
+* [Public API](#public-api)
+* [Configuration screen](#configuration-screen)
+    * [🍏 iOS](./configscreen/ios-config-screen.md)
+    * [🤖 Android](./configscreen/android-config-screen.md)
+        * [How to use](./configscreen/android-config-screen.md#how-to-use)
+        * [Theming](./configscreen/android-config-screen.md#theming)
+* [Startup arguments](#startup-arguments)
+    * [🍏 iOS](./startuparguments/ios-startup-arguments.md)
+    * [🤖 Android](./startuparguments/android-startup-arguments.md)
+* 👷 [For developers](#-for-developers)
+* 📜 [License](../README.md#license)
+
+<br />
+
+The scope of the library is to help a library consumer to manage its configuration values. `DevTool` represents the main, and the single library domain object, which wraps a configuration value and encapsulates different actions(i.e., `persist`, `update`...) that could be performed with it.
+
+As the configuration values might be of different types, there is a set of different prebuilt `DevTool` implementations for each configuration value type in part. 
+
+<br />
+
+## Prebuilt dev tool types
+The currently prebuilt list of dev tool types makes it possible to handle all configuration values of primitive types like `String`, `Integer`, and `Floating-Point`. 
+Reference types are not supported yet.
+
+| Name                           | Config&nbsp;value&nbsp;type          | Yaml | Json | Memory | Description                                                                                                  |                                                                                                                                                  |
+|--------------------------------|----------------------------|:----:|:----:|:------:|--------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Toggle](tools/toggle-tool.md) | `Boolean`                  |  ➕  |  ➕  |   ➕   | Allows to store, update, and consume boolean config values.                                                  | <img width="600" alt="toggle-tool" src="https://user-images.githubusercontent.com/12527390/80479540-d19b5700-8957-11ea-8f06-293b75a6db6c.png" /> |
+| [Text](tools/text-tool.md)     | `String` `Integer` `Float` |  ➕  |  ➕  |   ➕   | Allows to store, update, and consume text and numeric config values.                                         | <img width="600" alt="text-tool" src="https://user-images.githubusercontent.com/12527390/80484673-c862b800-8960-11ea-81fb-43159c004050.png" />   |
+| [Enum](tools/enum-tool.md)     | `String` `Integer` `Float` |  ➕  |  ➕  |   ➕   | Allows to store, update, and consume text and numeric config values. You set a limited config value options. | <img width="600" alt="enum-tool" src="https://user-images.githubusercontent.com/12527390/80527242-b9016000-899c-11ea-8ed7-d7f17d4f10b4.png" />   |
+| [Time](tools/time-tool.md)     | `Long`                     |  ➕  |  ➖  |   ➕   | Allows to store, update, and consume time config values. The config value is stored as Long in ms.           | <img width="600" alt="time-tool" src="https://user-images.githubusercontent.com/12527390/80527422-0087ec00-899d-11ea-89eb-9c5afce8f7ce.png" />   |
+| [Group](tools/group-tool.md)   | `DevTool`                  |  ➕  |  ➕  |   ➕   | Allows to group tools that belong to the same context.                                                       | <img width="600" alt="group-tool" src="https://user-images.githubusercontent.com/12527390/80527585-42189700-899d-11ea-96cc-d993f31608cf.png" />  |
+
+## 👷 Custom dev tool types
+In case the prebuilt dev tools are not sufficient, a library consumer might extend the library with its own dev tools.
+
+[<img width="64" src="https://user-images.githubusercontent.com/12527390/80728962-3d282480-8b10-11ea-9d64-94b19b16437e.png"/>](customtools/custom-tools-ios.md)
+[<img width="64" src="https://user-images.githubusercontent.com/12527390/80728603-cbe87180-8b0f-11ea-916f-df88789ce0be.png"/>](customtools/custom-tools-android.md)
+
+## Configuration sources
+
+Currently, the library supports 3 dev tools sources Yaml, Json, and Memory. However, in case you 
+need to use a custom one, you might add it very merely. Check how to do this [here](#-custom-sources).
+
+### Prebuilt sources
+
+<table class="tg">
+    <tr>
+        <td></td>
+        <td>🤖 Android</td>
+        <td>🍏 iOS</td>
+    </tr>
+    <tr>
+        <th>Yaml</th>
+        <td width="50%">
+            <pre lang="kotlin">val src = DevToolsSources.yaml(
+   assetManager = assets,
+   fileName = "dev-tools.yml"
+)</pre>
+        </td>
+        <td width="50%">
+            <pre lang="Swift">Not ready yet.</pre>
+        </td>
+    </tr>
+    <tr>
+        <th>Json</th>
+        <td width="50%">
+            <pre lang="kotlin">val src = DevToolsSources.json(
+   assetManager = assets,
+   fileName = "dev-tools.json"
+)</pre>
+        </td>
+        <td width="50%">
+            <pre lang="Swift">Not ready yet.</pre>
+        </td>
+    </tr>
+    <tr>
+        <th>Memory</th>
+        <td width="50%">
+            <pre lang="kotlin">val tools: Map&ltString, DevTool&lt*&gt&gt = mapOf(
+   "toggle-tool" to ToggleTool(default = true),
+   "text-tool" to TextTool(default = 3.0),
+   "time-tool" to TimeTool(days = 1)
+)
+val src = DevToolsSources.memory(tools)</pre>
+        </td>
+        <td width="50%">
+            <pre lang="swift">Not ready yet.</pre>
+        </td>
+    </tr>
+</table>
+
+<br/>
+
+### 👷 Custom sources
+
+To add a new custom source you just need to:
+
+1. Create a custom dev tools reader
+
+    The reader is the place where you should gather the dev tools data from your own source and
+    convert it to a collection of key-value pairs. Where the key is a unique dev tool key and the 
+    value is the actual dev tool.
+
+    <table class="tg">
+        <tr>
+            <td>🤖 Android</td>
+            <td>🍏 iOS</td>
+        </tr>
+        <tr>
+            <td width="50%">
+                 <pre lang="Kotlin">class MyCustomDevToolsReader : DevToolsReader {
+        override fun getDevTools(): Map<String, DevTool<*>> {
+            return mapOf(
+                "toggle-tool" to ToggleTool(default = true),
+                "text-tool" to TextTool(default = 3.0),
+                "time-tool" to TimeTool(days = 1)
+            )
+        }
+    }</pre>
+            </td>
+            <td width="50%">
+                <pre lang="swift">Not ready yet.</pre>
+            </td>
+        </tr>
+    </table>
+
+2. Create the actual source
+
+    You can do this by implementing [DevToolsSource](../devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/core/reader/DevToolsSource.kt)
+    
+    <table class="tg">
+        <tr>
+            <td>🤖 Android</td>
+            <td>🍏 iOS</td>
+        </tr>
+        <tr>
+            <td width="50%">
+                 <pre lang="Kotlin">class MyCustomSource : DevToolsSource {
+        override fun getReader(): DevToolsReader {
+            return MyCustomDevToolsReader()
+        }
+    }</pre>
+            </td>
+            <td width="50%">
+                <pre lang="swift">Not ready yet.</pre>
+            </td>
+        </tr>
+    </table>
+    
+## Public API
+To access and manipulate your configuration values programmatically from your's app code you'll need
+too have access to a [DevTools](../devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt) instance.
+
+**Create a dev tools instance**
+
+You'll need to provide at least 2 parameters to create a new [DevTools](../devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt) instance which are:
+
+1. `name`: a unique for your app instance dev tools id;
+2. `devToolsSources`: a list of dev tools sources;
+3. `onConfigUpdate` (optional): a config values update listener.
+
+<table class="tg">
+    <tr>
+        <td>🤖 Android</td>
+        <td>🍏 iOS</td>
+    </tr>
+    <tr>
+        <td width="50%">
+             <pre lang="Kotlin">val source = DevToolsSources.yaml(assets, "dev-tools.yml")
+val devtools = DevTools.create("TOOLS", source)<br />
+// or you can provide more sources<br />
+val memory = DevToolsSources.memory(tools)
+val yml = DevToolsSources.yaml(assets, "dev-tools.yml")
+val json = DevToolsSources.json(assets, "dev-tools.json")
+val devtools = DevTools.create("TOOLS", memory, yml, json)</pre>
+        </td>
+        <td width="50%">
+            <pre lang="swift">Not ready yet.</pre>
+        </td>
+    </tr>
+</table>
+
+**Access configuration**
+
+<table class="tg">
+    <tr>
+        <td>🤖 Android</td>
+        <td>🍏 iOS</td>
+    </tr>
+    <tr>
+        <td width="50%">
+             <pre lang="Kotlin">val value: Boolean = devtools.getValue("toggle-tool")</pre>
+        </td>
+        <td width="50%">
+            <pre lang="swift">Not ready yet.</pre>
+        </td>
+    </tr>
+</table>
+
+**React on configuration changes**
+
+The call back will be invoked whenever a new configuration value gets updated.
+`isCriticalUpdate` will be true just in case at least one dev tool that you marked as critical using 
+the critical flag will be updated.
+
+<table class="tg">
+    <tr>
+        <td>🤖 Android</td>
+        <td>🍏 iOS</td>
+    </tr>
+    <tr>
+        <td width="50%">
+             <pre lang="Kotlin">devtools.onConfigUpdated = { isCriticalUpdate -> 
+    /* React on configuration changes*/ 
+}</pre>
+        </td>
+        <td width="50%">
+            <pre lang="swift">Not ready yet.</pre>
+        </td>
+    </tr>
+</table>
+
+**Access group child configuration value**
+<table class="tg">
+    <tr>
+        <td>🤖 Android</td>
+        <td>🍏 iOS</td>
+    </tr>
+    <tr>
+        <td width="50%">
+             <pre lang="Kotlin">val value: Boolean = devtools.getGroup("toggle-tool")
+             .getValue("toggle-tool")<br/>             
+// or<br/>
+val value: Boolean = devtools
+             .getGroup("toggle-tool")
+             .getGroup("toggle-inner-group")
+             .getValue("toggle-tool")</pre>
+        </td>
+        <td width="50%">
+            <pre lang="swift">Not ready yet.</pre>
+        </td>
+    </tr>
+</table>
+
+**Check if configuration is enabled**
+<table class="tg">
+    <tr>
+        <td>🤖 Android</td>
+        <td>🍏 iOS</td>
+    </tr>
+    <tr>
+        <td width="50%">
+             <pre lang="Kotlin">val isEnabled = devtools.isEnabled("toggle-tool")<br/>
+// or<br/>
+val isEnabled = devtools
+            .getGroup("toggle-tool")
+            .getGroup("toggle-inner-group")
+            .isEnabled("toggle-tool")</pre>
+        </td>
+        <td width="50%">
+            <pre lang="swift">Not ready yet.</pre>
+        </td>
+    </tr>
+</table>
+
+**Get all configuration as JSON**
+
+Note that the lambda parameter is nothing else than a simple predicate(a filter). You can use it
+to filter out the configuration values that will reach the final JSON result. 
+
+For example, you can filter and get just the enabled config, as shown in the example.
+
+<table class="tg">
+    <tr>
+        <td>🤖 Android</td>
+        <td>🍏 iOS</td>
+    </tr>
+    <tr>
+        <td width="50%">
+             <pre lang="Kotlin">devtools.getAllConfigAsJson { tool -> tool.isEnabled }</pre>
+        </td>
+        <td width="50%">
+            <pre lang="swift">Not ready yet.</pre>
+        </td>
+    </tr>
+</table>
+
+## Configuration screen
+One of the easiest ways to update a configuration value is a good user interface. The library is able to generate a configuration screen dynamically based on your configuration file.
+
+[<img width="64" src="https://user-images.githubusercontent.com/12527390/80728962-3d282480-8b10-11ea-9d64-94b19b16437e.png"/>](configscreen/ios-config-screen.md)
+[<img width="64" src="https://user-images.githubusercontent.com/12527390/80728603-cbe87180-8b0f-11ea-916f-df88789ce0be.png"/>](configscreen/android-config-screen.md)
+
+## Startup arguments
+Sometimes we might need to run the app preconfigured. The most common use case could be an automated test, for example. So the best way to run the app preconfigured is to run it from a terminal and pass some startup arguments. The library provides a similar feature, but to make use of it, you must integrate it first.
+
+[<img width="64" src="https://user-images.githubusercontent.com/12527390/80728962-3d282480-8b10-11ea-9d64-94b19b16437e.png"/>](startuparguments/ios-startup-arguments.md)
+[<img width="64" src="https://user-images.githubusercontent.com/12527390/80728603-cbe87180-8b0f-11ea-916f-df88789ce0be.png"/>](startuparguments/android-startup-arguments.md)
+
+## 👷 For Developers
+If you know how to fix an issue, consider opening a pull request for it. 🙏
+
+You can read this repository’s [contributing guidelines](../CONTRIBUTING.md) to learn how to open a good pull request.
+
+### Modules
+
+<div style="text-align:center"><img align="right" width="500" alt="modules-dependencies" src="https://user-images.githubusercontent.com/12527390/80819650-06204480-8bde-11ea-887f-258083223545.png"/></div>
+
+The library is composed of 5 modules:
+
+1. **Common**: the actual multi-platform module which contains all business models and logic; 
+
+2. **Library Android**: an Android module which contains just Android native view implementations;
+
+3. **Library iOS**: an iOS framework which contains just iOS native view implementations;
+
+4. **Sample Android**: an Android library consumer which serves as an Android library features demo.
+
+5. **Sample iOS**: an iOS library consumer which serves as an iOS library features demo.
+
+<br/> 
+
+### Build process
+
+| Android                                                                                                                                                                                                                                                                            | iOS                                                                                                                                                                                                                                                                                                                                                                                  |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| You may use `./gradlew assemble` to generate a new android library. <br/><br/> The Android library generation is straight forward. <br/><br/> First of all, an AAR is generated from the Common module, which is then used to generate another AAR for the Android Library itself. | The iOS framework generation is a bit more complex but not much harder than the Android one. <br/><br/> First of all, you need to build a `Fat Framework(FF)`.<br/> You can do this by running `./gradlew releaseFatFramework`. <br/><br/> After this command succeeds, you'll notice the framework inside the iOS library package. <br/><br/> Now you can build the library itself. |
+
+
+### Code Quality
+
+<table>
+    <tr>
+        <th>Common</th>
+        <th>Android</th>
+        <th>iOS</th>
+    </tr>
+    <tr>
+        <td>
+           - <a href="https://github.com/pinterest/ktlint">ktlint</a><br />
+           - <a href="https://github.com/arturbosch/detekt">detekt</a>
+        </td>
+         <td>
+           - <a href="https://github.com/pinterest/ktlint">ktlint</a><br />
+           - <a href="https://github.com/arturbosch/detekt">detekt</a><br />
+           - <a href="https://developer.android.com/studio/write/lint">lint</a>
+        </td>
+        <td>
+            Not ready yet.
+        </td>
+    </tr>
+</table>
+
+### Handy gradle tasks
+
+1. `./gradlew clean` will remove all build directories **together with the iOS Fat Framework**
+2. `./gradlew assembe` will generate `release`/`debug` `aar`s and also the iOS `Fat Framework`
+3. `./gradlew releaseFatFramework` will generate the iOS `Fat Framework`
+3. `./gradlew testDebugUnitTest` runes all JVM modules unit tests
+4. `./gradlew detekt ktlint lint testDebugUnitTest assembleDebug` will run all quality checks and will assemble the frameworks
+
+In case you're working on the library you might find useful this alias:
+```shell script
+alias checktools='./gradlew detekt ktlint lint testDebugUnitTest assembleDebug'
+```
+It will run all style checks, unit tests, and will assemble all artifacts. 
+
+### Deployment
+
+Not ready yet.

--- a/documentation/quickstart/quick-start-android.md
+++ b/documentation/quickstart/quick-start-android.md
@@ -1,0 +1,162 @@
+[<img width="90" align="right" src="https://user-images.githubusercontent.com/12527390/80737506-4ae3a700-8b1c-11ea-92b7-a137982595ea.png"/>](#)
+
+# Quick start 
+
+1. **Add the library dependency**
+
+    TBA
+
+<br />
+
+2. **Add a configuration file**
+
+    Currently, you can set up your app with dev tools directly from the code or using a [YAML](https://yaml.org/) or [JSON Schema Draft-07](https://json-schema.org/draft-07/json-schema-validation.html) configuration file.
+    The example will be based on YML; however, using other sources is not hard. 
+    
+    You can check the [supported dev tools](../documentation.md#supported-dev-tools) and [configuration sources](../documentation.md#configuration-sources) for more information.
+    
+    So, create a `dev-tools.yml` configuration file inside your app's `assets` directory.
+    
+    ```yaml
+    yml-toggle-tool: !toggle {
+      title: "Toggle tool",
+      description: "A boolean configuration value tool",
+      canBeDisabled: true,
+      defaultEnabledValue: false,
+      isCritical: true,
+      default: true
+    }
+    
+    yml-enum-tool: !enum {
+      title: "Enum tool",
+      description: "An enum configuration value tool",
+      canBeDisabled: true,
+      defaultEnabledValue: false,
+      isCritical: false,
+      allowCustom: true,
+      defaultValueKey: first-option,
+      options: {
+        first-option: "First Option Value",
+        second-option: "Second Option Value",
+        third-option: "Third Option Value",
+      }
+    }
+    ```
+   
+<br />
+
+3. **Create a tools source**
+
+    Before we get to creating the [DevTools](../../devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt) object, the object which you'll use to interact with the library we need to learn how to create a source for the `dev-tools.yml` configuration file we added in the previous step.
+    
+    You can check all [configuration sources](../documentation.md#configuration-sources) the library supports at the moment. We need to use the YML one, though.
+    
+    ```kotlin
+    val source = DevToolsSources.yaml(assets, "dev-tools.yml")
+    ```
+
+<br />
+
+4. **Create a dev tools instance**
+    
+    [DevTools](../../devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt) is the object you'll use to interact with the library from yours app code because it represents the library interface.
+    You'll be able to read, update, and perform many other useful actions with your config using it.
+    
+    Check out the whole [public api](../documentation.md#public-api) for more information.
+    
+    Most probably, you'll want to reuse this instance inside the whole app, that's why I suggest you wrap it in a custom class just to decouple the library from your project.
+    
+    I'll place it directly inside the Application class just for the sake of example. This is not the best design, though.
+    
+    ```Kotlin
+    class SampleApplication : Application() {
+        lateinit var devtools: DevTools private set
+    
+        companion object {
+            lateinit var application: SampleApplication
+                private set
+        }
+    
+        override fun onCreate() {
+            super.onCreate()
+            application = this
+    
+            val source = DevToolsSources.yaml(assets, "dev-tools.yml")
+            devtools = DevTools.create("DEV_TOOLS", source)
+        }
+    }
+    ```
+
+<br />
+
+5. **Add a new configuration activity**
+
+    One of the easiest ways to update a configuration value is a good user interface. 
+    The library can generate one for you using just the `dev-tools.yml` configuration file you've provided.
+    
+    You just need to create a separate activity for the configuration screen and open it whenever you need to update your app config.
+    
+    ```Kotlin
+    class DevToolsActivity: AppCompatActivity() {
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
+    
+            val contentView = findViewById<ViewGroup>(android.R.id.content)
+            DevToolsConfigurationScreen.attachToView(contentView, SampleApplication.application.devtools)
+        }
+    }
+    ```
+    You can attach this config screen view to any other view from your app.
+    You can even adjust its theme if you don't like the default one, check out how to do this [here](../configscreen/android-config-screen.md).
+
+<br />
+
+6. **Integrate the startup arguments**
+
+    You might need to run your app preconfigured. The most common use case would be an automation test, for example. 
+    This is also possible, and to make use of this feature, you must integrate it first.
+    
+    Go to the very first activity to be opened from your app, in my sample, it is called `MainActivity` and add the following call.
+    ```Kotlin
+    SampleApplication.application.devtools.updateFromBundle(intent.extras)
+    ```
+   
+   Now you can go and check how to use the [startup arguments](../startuparguments/android-startup-arguments.md) and start using them.
+
+# Congratulations 🎉 
+<img width="300" alt="dev-tools" align="right" src="https://user-images.githubusercontent.com/12527390/80519661-feb82b80-8990-11ea-8a6a-07e0d62a1aac.png"/>
+
+You've just finished the integration process Now you should be able to update and consume your app config way more comfortable than before.
+
+#### Configuration screen
+
+Just go and open the Configuration activity you've defined, and you should see your configuration screen.
+
+#### Startup arguments
+
+You can also try to update your app config from startup arguments.
+
+```shell script
+adb shell am start --ez yml-toggle-tool false com.maximbircu.devtools/com.maximbircu.devtools.MainActivity
+```
+
+#### Accessing config values
+
+You can use the [DevTools](../../devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt) instance to access the configuration values of your dev tools.
+```kotlin
+val value: Boolean = devtools.getValue("toggle-tool")
+```
+
+Or to check if your dev tool is enabled
+
+```kotlin
+val isEnabled = devtools.isEnabled("toggle-tool")
+```
+
+And react on its configuration changes
+
+```kotlin
+devtools.onConfigUpdated = { isCriticalUpdate -> 
+    /* React on configuration changes*/ 
+}
+```

--- a/documentation/quickstart/quick-start-android.md
+++ b/documentation/quickstart/quick-start-android.md
@@ -18,7 +18,7 @@
     So, create a `dev-tools.yml` configuration file inside your app's `assets` directory.
     
     ```yaml
-    yml-toggle-tool: !toggle {
+    toggle-tool: !toggle {
       title: "Toggle tool",
       description: "A boolean configuration value tool",
       canBeDisabled: true,
@@ -27,7 +27,7 @@
       default: true
     }
     
-    yml-enum-tool: !enum {
+    enum-tool: !enum {
       title: "Enum tool",
       description: "An enum configuration value tool",
       canBeDisabled: true,
@@ -137,7 +137,7 @@ Just go and open the Configuration activity you've defined, and you should see y
 You can also try to update your app config from startup arguments.
 
 ```shell script
-adb shell am start --ez yml-toggle-tool false com.maximbircu.devtools/com.maximbircu.devtools.MainActivity
+adb shell am start --ez toggle-tool false com.maximbircu.devtools/com.maximbircu.devtools.MainActivity
 ```
 
 #### Accessing config values

--- a/documentation/quickstart/quick-start-ios.md
+++ b/documentation/quickstart/quick-start-ios.md
@@ -1,0 +1,16 @@
+[<img width="90" align="right" src="https://user-images.githubusercontent.com/12527390/80737507-4c14d400-8b1c-11ea-9b82-d44718783a2e.png"/>](#)
+
+# Quick start 
+<br/> <br/> <br/> 
+<div align="center"><img alt="work in progress" src="https://user-images.githubusercontent.com/12527390/80824719-b0e93080-8be7-11ea-8be4-8294a6652cb8.png" /></div>
+<br/> <br/> <br/> <br/>
+
+The iOS library is not ready yet. 😞
+
+## 👷 For Developers
+
+Consider opening a pull request to accelerate its release. 🙏
+
+Check out the remaining work till the first release [here](https://github.com/maximbircu/devtools-library/issues?q=is%3Aopen+is%3Aissue+label%3AiOS).
+
+You can read this repository’s [contributing guidelines](../CONTRIBUTING.md) to learn how to open a good pull request.

--- a/documentation/quickstart/quick-start.md
+++ b/documentation/quickstart/quick-start.md
@@ -1,0 +1,11 @@
+# Choose your platform
+Android and iOS are the only supported platforms for now.
+
+[<img width="64" src="https://user-images.githubusercontent.com/12527390/80737507-4c14d400-8b1c-11ea-9b82-d44718783a2e.png"/>](quick-start-ios.md)
+[<img width="64" src="https://user-images.githubusercontent.com/12527390/80737506-4ae3a700-8b1c-11ea-92b7-a137982595ea.png"/>](quick-start-android.md)
+
+## 👷 For Developers
+
+Consider opening pull requests to add support for other platforms too. 🙏 
+
+You can read this repository’s [contributing guidelines](../CONTRIBUTING.md) to learn how to open a good pull request.

--- a/documentation/startuparguments/android-startup-arguments.md
+++ b/documentation/startuparguments/android-startup-arguments.md
@@ -28,7 +28,7 @@ Where:
 
 For example: 
 ```shell script
-adb shell am start --ez yml-toggle-tool false com.maximbircu.devtools/com.maximbircu.devtools.MainActivity
+adb shell am start --ez toggle-tool false com.maximbircu.devtools/com.maximbircu.devtools.MainActivity
 ```
 
 ## ℹ️ Build the right command

--- a/documentation/startuparguments/android-startup-arguments.md
+++ b/documentation/startuparguments/android-startup-arguments.md
@@ -1,0 +1,49 @@
+[<img width="90" align="right" src="https://user-images.githubusercontent.com/12527390/80737506-4ae3a700-8b1c-11ea-92b7-a137982595ea.png"/>](#)
+
+# Startup arguments
+
+Well, the integration is pretty simple, you just need to find the activity that runs very first in your application and add the line below to its `onCreate` method.
+
+```Kotlin
+SampleApplication.application.devtools.updateFromBundle(intent.extras)
+```
+Now, whenever you start your app, the library will receive the very first intent bundle and will try to extract the startup arguments from it and update configuration values.
+
+Thus, after you redeploy the app to your device, you'll be able to use the command below.
+
+```shell script
+adb shell am start <argument-flag> <tool-key> <config-value> -n <app-package-name>/<fully-qualified-activity-class-name>
+```
+Where:
+* **argument-flag:** indicates the type of the configuration value extra. You can read more about this [here](https://developer.android.com/studio/command-line/adb#IntentSpec);
+   * `--es`: for string configuration values;
+   * `--ez`: for boolean configuration values;
+   * `--ei`: for int configuration values;
+   * `--el`: for long configuration values;
+   * `--ef`: for floating-point configuration values.
+* **tool-key:** is the unique key of the dev tool you want to update. You might take a look at the configuration file to find it, or you can use the tool to help dialog from the configuration screen;
+* **config-value:** is the configuration value you want this tool to take after the app start;
+* **app-package-name:** os the package name of your app;
+* **fully-qualified-activity-class-name:** is the qualified activity name which contains the LUNCH intent filter.
+
+For example: 
+```shell script
+adb shell am start --ez yml-toggle-tool false com.maximbircu.devtools/com.maximbircu.devtools.MainActivity
+```
+
+## ℹ️ Build the right command
+
+<img width="230" alt="help-dialog" align="right" src="https://user-images.githubusercontent.com/12527390/80735942-1d95f980-8b1a-11ea-9ea1-50bee8bd8907.png" />
+
+To build easier the shell command which will start your app preconfigured you can:
+
+1. Open the app and go to the configuration screen
+1. Find the tool you intend to update
+1. Press on the context menu button (three dots button from the right upper corner)
+1. Select the `Help` dialog menu
+1. You'll notice the correct startup argument at the bottom of the dialog.
+
+Now just run: 
+````shell script
+adb shell am start --ez toggle-tool false com.maximbircu.devtools/com.maximbircu.devtools.MainActivity
+````

--- a/documentation/startuparguments/ios-startup-arguments.md
+++ b/documentation/startuparguments/ios-startup-arguments.md
@@ -1,0 +1,16 @@
+[<img width="90" align="right" src="https://user-images.githubusercontent.com/12527390/80737507-4c14d400-8b1c-11ea-9b82-d44718783a2e.png"/>](#)
+
+# Startup arguments
+<br/> <br/> <br/> 
+<div align="center"><img alt="work in progress" src="https://user-images.githubusercontent.com/12527390/80824719-b0e93080-8be7-11ea-8be4-8294a6652cb8.png" /></div>
+<br/> <br/> <br/> <br/>
+
+The iOS library is not ready yet. 😞
+
+## 👷 For Developers
+
+Consider opening a pull request to accelerate its release. 🙏
+
+Check out the remaining work till the first release [here](https://github.com/maximbircu/devtools-library/issues?q=is%3Aopen+is%3Aissue+label%3AiOS).
+
+You can read this repository’s [contributing guidelines](../CONTRIBUTING.md) to learn how to open a good pull request.

--- a/documentation/tools/enum-tool.md
+++ b/documentation/tools/enum-tool.md
@@ -1,0 +1,108 @@
+# Enum
+A text dev tool allows you to store, update, and consume `string`, `integer`, and `floating-point` configuration values but limits the allowed configuration value options.
+
+<table>
+    <tr>
+        <th>🤖 Android</th>
+        <th>🍏 iOS</th>
+    </tr>
+    <tr>
+        <td width="50%">
+           <img alt="enum-tool" src="https://user-images.githubusercontent.com/12527390/80527242-b9016000-899c-11ea-8ed7-d7f17d4f10b4.png" />
+        </td>
+        <td width="50%">
+            Not ready yet.
+        </td>
+    </tr>
+</table>
+
+## Parameters
+
+| Name                |    Type   | Default | Optional | Description                                                                                                   |
+|---------------------|:---------:|:-------:|:--------:|---------------------------------------------------------------------------------------------------------------|
+| title               |  `string` |   `""`  |    ➕    | A tool title that will be displayed inside the configuration screen.                                          |
+| description         |  `string` |   `""`  |    ➕    | A short description explaining what the configuration value is doing and what changes might bring its update. |
+| canBeDisabled       | `boolean` | `false` |    ➕    | Will add a checkbox to the tool, which will allow disabling it.                                               |
+| defaultEnabledValue | `boolean` |  `true` |    ➕    | The tool will be enabled by default if true and disabled vice-versa.                                          |
+| isCritical          | `boolean` | `false` |    ➕    | The tool which will have it set to true will trigger critical updates.                                        |
+| allowCustom         | `boolean` | `false` |    ➕    | The tool will allow the user to input custom config values if true and will dine it vice-versa.               |
+
+#### Yaml
+
+| Name            |   Type   | Default | Optional | Description                                                                                                                                                                                         |
+|-----------------|:--------:|:-------:|:--------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| options         | `object` |   null  |    ➖    | Use this parameter to provide a set of available configuration options the user should be able to select.                                                                                           |
+| defaultValueKey | `string` |  `null` |    ➖    | The key of the default configuration option that should be preselected at the first app launch.                                                                                                     |
+| optionsProvider | `object` |   null  |    ➕    | It's used by the enum tool to extract the available configuration options to be selected if provided. The options provided directly inside the YML configuration file will be ignored in this case. |
+#### Json
+
+| Name    |   Type   | Default | Optional | Description                                                                                                                                                                                                                                                                                 |
+|---------|:--------:|:-------:|:--------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| enum    |  `arry`  |   null  |    ➖    | Use this parameter to provide a set of available configuration options the user should be able to select.                                                                                                                                                                                   |
+| default | `string` |  `null` |    ➖    | The default configuration value which will be preselected at the first app launch. Note that we're not providing keys in comparison with the YML API; this is because we want to make use of the JSON schema enum type. The library will use the configuration values as keys in this case. |
+
+## Sources
+
+### Yaml
+
+```Yaml
+yml-enum-tool: !enum {
+  title: "Enum tool",
+  description: "An enum configuration value tool",
+  canBeDisabled: true,
+  defaultEnabledValue: false,
+  isCritical: false,
+  allowCustom: true,
+  defaultValueKey: first-option,
+  options: {
+    first-option: "First Option Value",
+    second-option: "Second Option Value",
+    third-option: "Third Option Value",
+  }
+}
+```
+
+### Json
+```Json
+"enum-tool": {
+  "type": "string",
+  "title": "Enum tool",
+  "description": "An enum configuration value tool",
+  "canBeDisabled": true,
+  "defaultEnabledValue": false,
+  "isCritical": true,
+  "default": "Second Option Value",
+  "enum": [
+    "First Option Value",
+    "Second Option Value",
+    "Third Option Value"
+  ],
+  "allowCustom": true
+}
+```
+
+### Memory
+#### 🍏 iOS
+```Swift
+TBA
+```
+#### 🤖 Android
+```Kotlin
+val tool = EnumTool(
+    defaultValueKey = "first-option",
+    allowCustom = true,
+    optionsProvider = object : EnumOptionsProvider {
+        override fun getOptions() = mapOf(
+            "first-option" to "First Option",
+            "second-option" to "Second Option",
+            "third-option" to "Third Option"
+        )
+    }
+)
+
+tool = title = "Enum tool"
+tool = description = "An enum configuration value tool"
+tool = canBeDisabled = true
+tool = defaultEnabledValue = false
+tool = isCritical = true
+```

--- a/documentation/tools/enum-tool.md
+++ b/documentation/tools/enum-tool.md
@@ -46,7 +46,7 @@ A text dev tool allows you to store, update, and consume `string`, `integer`, an
 ### Yaml
 
 ```Yaml
-yml-enum-tool: !enum {
+enum-tool: !enum {
   title: "Enum tool",
   description: "An enum configuration value tool",
   canBeDisabled: true,

--- a/documentation/tools/group-tool.md
+++ b/documentation/tools/group-tool.md
@@ -1,0 +1,132 @@
+# Group
+A dev tool allows you to group together a set of dev tools that are relevant and share the same context.
+
+<table>
+    <tr>
+        <th>🤖 Android</th>
+        <th>🍏 iOS</th>
+    </tr>
+    <tr>
+        <td width="50%">
+           <img  alt="group-tool" src="https://user-images.githubusercontent.com/12527390/80527585-42189700-899d-11ea-96cc-d993f31608cf.png" />
+        </td>
+        <td width="50%">
+            Not ready yet.
+        </td>
+    </tr>
+</table>
+
+## Parameters
+
+| Name  |   Type   | Default | Optional | Description                                                           |
+|-------|:--------:|:-------:|:--------:|-----------------------------------------------------------------------|
+| title | `string` |   `""`  |    ➕    | A tool title that will be displayed inside the configuration screen.  |
+
+#### Yaml
+
+| Name  |   Type   | Default | Optional | Description                                            |
+|-------|:--------:|:-------:|:--------:|--------------------------------------------------------|
+| tools | `object` |   null  |    ➖    | A list of dev tool objects you want to group together. |
+
+#### Json
+
+| Name       |   Type   | Default | Optional | Description                                            |
+|------------|:--------:|:-------:|:--------:|--------------------------------------------------------|
+| properties | `object` |   null  |    ➖    | A list of dev tool objects you want to group together. |
+
+## Sources
+
+### Yaml
+Below is presented an example of a group tool configuration in YML format. Note that you should use the `!group` type.
+```Yaml
+yml-tools-group: !group {
+  title: "Tools group",
+  tools: {
+    yml-toggle-tool: !toggle {
+      title: "Toggle tool",
+      default: true
+    },
+    yml-text-tool: !text {
+      title: "Text tool (String)",
+      default: "Here can go any text value"
+    },
+    yml-time-tool: !time {
+      title: "Time tool",
+      days: 1,
+      hours: 2
+    },
+    yml-enum-tool: !enum {
+      title: "Enum tool",
+      defaultValueKey: first-option,
+      options: {
+        first-option: "First Option Value",
+        second-option: "Second Option Value",
+        third-option: "Third Option Value",
+      }
+    }
+  }
+}
+```
+### Json
+Below is an example of a group tool configuration in JSON Schema format. Note that you should add the `"type": "object"` to the configuration object to make it map to a group tool.
+```Json
+"tools-group": {
+  "type": "object",
+  "title": "Tools group",
+  "properties": {
+    "toggle-tool": {
+      "type": "boolean",
+      "title": "Toggle tool",
+      "default": true
+    },
+    "text-tool": {
+      "type": "string",
+      "title": "Text tool (String)",
+      "default": " String config value"
+    },
+    "enum-tool": {
+      "type": "string",
+      "title": "Enum tool",
+      "default": "Second Option Value",
+      "enum": [
+        "First Option Value",
+        "Second Option Value",
+        "Third Option Value"
+      ]
+    }
+  }
+}
+```
+### Memory
+#### 🍏 iOS
+```Swift
+TBA 
+```
+#### 🤖 Android
+```Kotlin
+val tool = GroupTool(
+    tools = mapOf(
+        "toggle-tool" to ToggleTool(default = false).apply { title = "Toggle tool" },
+        "text-tool" to TextTool(
+            default = "Here can go any text value"
+        ).apply { title = "Text tool (String)" },
+        "time-tool" to TimeTool(
+            days = 1,
+            hours = 2,
+            minutes = 3,
+            seconds = 4,
+            milliseconds = 5
+        ).apply { title = "Time tool" },
+        "enum-tool" to EnumTool(
+            defaultValueKey = "first-option",
+            optionsProvider = object : EnumOptionsProvider {
+                override fun getOptions() = mapOf(
+                    "first-option" to "First Option",
+                    "second-option" to "Second Option",
+                    "third-option" to "Third Option"
+                )
+            }
+        ).apply { title = "Enum tool" }
+    )
+).apply { title = "Tools group" }
+```

--- a/documentation/tools/group-tool.md
+++ b/documentation/tools/group-tool.md
@@ -39,23 +39,23 @@ A dev tool allows you to group together a set of dev tools that are relevant and
 ### Yaml
 Below is presented an example of a group tool configuration in YML format. Note that you should use the `!group` type.
 ```Yaml
-yml-tools-group: !group {
+tools-group: !group {
   title: "Tools group",
   tools: {
-    yml-toggle-tool: !toggle {
+    toggle-tool: !toggle {
       title: "Toggle tool",
       default: true
     },
-    yml-text-tool: !text {
+    text-tool: !text {
       title: "Text tool (String)",
       default: "Here can go any text value"
     },
-    yml-time-tool: !time {
+    time-tool: !time {
       title: "Time tool",
       days: 1,
       hours: 2
     },
-    yml-enum-tool: !enum {
+    enum-tool: !enum {
       title: "Enum tool",
       defaultValueKey: first-option,
       options: {

--- a/documentation/tools/text-tool.md
+++ b/documentation/tools/text-tool.md
@@ -1,0 +1,79 @@
+# Text
+A text dev tool allows you to store, update, and consume `string`, `integer`, and `floating-point` configuration values.
+
+<table>
+    <tr>
+        <th>🤖 Android</th>
+        <th>🍏 iOS</th>
+    </tr>
+    <tr>
+        <td width="50%">
+            <img width="300" alt="text-tool-string" align="left" src="https://user-images.githubusercontent.com/12527390/80484673-c862b800-8960-11ea-81fb-43159c004050.png" />
+            <img width="300" alt="text-tool-integer" align="left"  src="https://user-images.githubusercontent.com/12527390/80484702-d7496a80-8960-11ea-8025-de3abacbadcf.png" />
+            <img width="300" alt="text-tool-floating-point" src="https://user-images.githubusercontent.com/12527390/80484758-eb8d6780-8960-11ea-8198-2945091d1609.png" />
+        </td>
+        <td width="50%">
+            Not ready yet.
+        </td>
+    </tr>
+</table>
+
+## Parameters
+
+| Name                |            Type            | Default | Optional | Description                                                                                                           |
+|---------------------|:--------------------------:|:-------:|:--------:|-----------------------------------------------------------------------------------------------------------------------|
+| title               |          `string`          |   `""`  |    ➕    | A tool title that will be displayed inside the configuration screen.                                                  |
+| description         |          `string`          |   `""`  |    ➕    | A short description explaining what the configuration value is doing and what changes might bring its update.         |
+| canBeDisabled       |          `boolean`         | `false` |    ➕    | Will add a checkbox to the tool, which will allow disabling it.                                                       |
+| defaultEnabledValue |          `boolean`         |  `true` |    ➕    | The tool will be enabled by default if true and disabled vice-versa.                                                  |
+| isCritical          |          `boolean`         | `false` |    ➕    | The tool which will have it set to true will trigger critical updates.                                                |
+| hint                |          `string`          |   `""`  |    ➕    | A short configuration value description. It will be shown as a hint inside the input field whenever it will be empty. |
+| default             | `string` `integer` `float` |   n/a   |    ➖    | The default configuration value, any text or number.                                                                  |                                                            |
+
+## Sources
+
+### Yaml
+Below is an example of a text tool configuration in YML format. Note that you should use the `!text` type.
+
+```Yaml
+text-tool: !text {
+  title: "Text tool (String)",
+  description: "A text configuration value tool",
+  canBeDisabled: true,
+  defaultEnabledValue: false,
+  isCritical: false,
+  default: "Here can go any text value",
+  hint: "String config value"
+}
+```
+
+### Json
+Below is an example of a text tool configuration in JSON Schema format. Note that you should add the `"type": "string"` to the configuration object to make it map to a text tool.
+```Json
+"text-tool": {
+  "type": "string",
+  "title": "Text tool (String)",
+  "description": "A text configuration value tool",
+  "canBeDisabled": true,
+  "defaultEnabledValue": false,
+  "isCritical": false,
+  "default": "String config value",
+  "hint": "String config value"
+}
+```
+
+### Memory
+#### 🍏 iOS
+```Swift
+TBA 
+```
+#### 🤖 Android
+```Kotlin
+val tool = TextTool(default = "Here can go any text value", hint = "String config value")
+
+tool.title = "Text tool (String)"
+tool.description = "A text configuration value tool"
+tool.canBeDisabled = true
+tool.defaultEnabledValue = false
+tool.isCritical = false
+```

--- a/documentation/tools/time-tool.md
+++ b/documentation/tools/time-tool.md
@@ -38,7 +38,7 @@ A time dev tool allows you to store, update, and consume long(time in ms) config
 Below is an example of a time tool configuration in YML format. Note that you should use the `!time` type.
 
 ```Yml
-yml-time-tool: !time {
+time-tool: !time {
   title: "Time tool",
   description: "A time configuration value tool",
   canBeDisabled: true,

--- a/documentation/tools/time-tool.md
+++ b/documentation/tools/time-tool.md
@@ -1,0 +1,76 @@
+# Time
+
+A time dev tool allows you to store, update, and consume long(time in ms) configuration values.
+
+<table>
+    <tr>
+        <th>🤖 Android</th>
+        <th>🍏 iOS</th>
+    </tr>
+    <tr>
+        <td width="50%">
+           <img alt="time-dev-tool" src="https://user-images.githubusercontent.com/12527390/80527422-0087ec00-899d-11ea-89eb-9c5afce8f7ce.png" />
+        </td>
+        <td width="50%">
+            Not ready yet.
+        </td>
+    </tr>
+</table>
+
+## Parameters
+
+| Name                |    Type   | Default | Optional | Description                                                                                                   |
+|---------------------|:---------:|:-------:|:--------:|---------------------------------------------------------------------------------------------------------------|
+| title               |  `string` |   `""`  |    ➕    | A tool title that will be displayed inside the configuration screen.                                          |
+| description         |  `string` |   `""`  |    ➕    | A short description explaining what the configuration value is doing and what changes might bring its update. |
+| canBeDisabled       | `boolean` | `false` |    ➕    | Will add a checkbox to the tool, which will allow disabling it.                                               |
+| defaultEnabledValue | `boolean` |  `true` |    ➕    | The tool will be enabled by default if true and disabled vice-versa.                                          |
+| isCritical          | `boolean` | `false` |    ➕    | The tool which will have it set to true will trigger critical updates.                                        |
+| days                |   `long`  |   `0`   |    ➕    | Default time configuration value in days.                                                                     |
+| hours               |   `long`  |   `0`   |    ➕    | Default time configuration value in hours.                                                                    |
+| minutes             |   `long`  |   `0`   |    ➕    | Default time configuration value in minutes.                                                                  |
+| seconds             |   `long`  |   `0`   |    ➕    | Default time configuration value in seconds.                                                                  |
+| milliseconds        |   `long`  |   `0`   |    ➕    | Default time configuration value in milliseconds.                                                             |
+
+## Sources
+
+### Yml
+Below is an example of a time tool configuration in YML format. Note that you should use the `!time` type.
+
+```Yml
+yml-time-tool: !time {
+  title: "Time tool",
+  description: "A time configuration value tool",
+  canBeDisabled: true,
+  defaultEnabledValue: false,
+  isCritical: true,
+  days: 1,
+  hours: 2,
+  minutes: 3,
+  seconds: 4,
+  milliseconds: 5,
+}
+```
+
+### 👷 Json
+Not supported yet 😞
+
+Consider opening a pull request to add this feature. 🙏
+
+You can read this repository’s [contributing guidelines](../CONTRIBUTING.md) to learn how to open a good pull request.
+
+### Memory
+#### 🍏 iOS
+```Swift
+TBA 
+```
+#### 🤖 Android
+```Kotlin
+val tool = TimeTool(days = 1, hours = 2, minutes = 3, seconds = 4, milliseconds = 5)
+
+tool = title = "Time tool"
+tool = description = "A time configuration value tool"
+tool = canBeDisabled = true
+tool = defaultEnabledValue = false
+tool = isCritical = true
+```

--- a/documentation/tools/toggle-tool.md
+++ b/documentation/tools/toggle-tool.md
@@ -1,0 +1,73 @@
+# Toggle
+A toggle dev tool allows you to store, update, and consume boolean configuration values.
+
+<table>
+    <tr>
+        <th>🤖 Android</th>
+        <th>🍏 iOS</th>
+    </tr>
+    <tr>
+        <td width="50%">
+            <img alt="toggle-tool" src="https://user-images.githubusercontent.com/12527390/80479540-d19b5700-8957-11ea-8f06-293b75a6db6c.png" />
+        </td>
+        <td width="50%">
+            Not ready yet.
+        </td>
+    </tr>
+</table>
+
+## Parameters
+
+| Name                |    Type   | Default | Optional | Description                                                                                                   |
+|---------------------|:---------:|:-------:|:--------:|---------------------------------------------------------------------------------------------------------------|
+| title               |  `string` |   `""`  |    ➕    | A tool title that will be displayed inside the configuration screen.                                          |
+| description         |  `string` |   `""`  |    ➕    | A short description explaining what the configuration value is doing and what changes might bring its update. |
+| canBeDisabled       | `boolean` | `false` |    ➕    | Will add a checkbox to the tool, which will allow disabling it.                                               |
+| defaultEnabledValue | `boolean` |  `true` |    ➕    | The tool will be enabled by default if true and disabled vice-versa.                                          |
+| isCritical          | `boolean` | `false` |    ➕    | The tool which will have it set to true will trigger critical updates.                                        |
+| default             | `boolean` | `false` |    ➕    | The default boolean configuration value.                                                                      |
+
+## Sources
+
+### Yaml
+Below is an example of a toggle tool configuration in YML format. Note that you should use the `!toggle` type.
+```Yaml
+toggle-tool: !toggle {
+  title: "Toggle tool",
+  description: "A boolean configuration value tool",
+  canBeDisabled: true,
+  defaultEnabledValue: false,
+  isCritical: true,
+  default: true
+}
+```
+
+### Json
+Below is an example of a toggle tool configuration in JSON Schema format. Note that you should add the `"type": "boolean"` to the configuration object to make it map to a toggle tool.
+```Json
+"toggle-tool": {
+  "type": "boolean",
+  "title": "Toggle tool",
+  "description": "A boolean configuration value tool",
+  "canBeDisabled": true,
+  "defaultEnabledValue": false,
+  "isCritical": true,
+  "default": true
+}
+```
+
+### Memory
+#### 🍏 iOS
+```Swift
+TBA 
+```
+#### 🤖 Android
+```Kotlin
+val tool = ToggleTool(default = false)
+
+tool = title = "Toggle tool"
+tool = description = "A boolean configuration value dev tool"
+tool = canBeDisabled = true
+tool = defaultEnabledValue = false
+tool = isCritical = true
+```

--- a/samples/android/src/main/assets/dev-tools.json
+++ b/samples/android/src/main/assets/dev-tools.json
@@ -6,6 +6,9 @@
       "type": "boolean",
       "title": "Toggle tool",
       "description": "A boolean configuration value tool",
+      "canBeDisabled": true,
+      "defaultEnabledValue": false,
+      "isCritical": true,
       "default": true
     },
 
@@ -13,6 +16,9 @@
       "type": "string",
       "title": "Text tool (String)",
       "description": "A text configuration value tool",
+      "canBeDisabled": true,
+      "defaultEnabledValue": false,
+      "isCritical": false,
       "default": "String config value",
       "hint": "String config value"
     },
@@ -20,6 +26,9 @@
       "type": "integer",
       "title": "Text tool (Integer)",
       "description": "An integer number configuration value tool",
+      "canBeDisabled": true,
+      "defaultEnabledValue": false,
+      "isCritical": true,
       "default": 3,
       "hint": "Integer number config value"
     },
@@ -27,13 +36,20 @@
       "type": "number",
       "title": "Text tool (Floating point)",
       "description": "A floating-point number configuration value tool",
+      "canBeDisabled": true,
+      "defaultEnabledValue": false,
+      "isCritical": false,
       "default": 3.4,
       "hint": "Floating point number config value"
     },
 
-    "enum-tool-floating-point": {
+    "enum-tool": {
       "type": "string",
       "title": "Enum tool",
+      "description": "An enum configuration value tool",
+      "canBeDisabled": true,
+      "defaultEnabledValue": false,
+      "isCritical": true,
       "default": "Second Option Value",
       "enum": [
         "First Option Value",
@@ -50,18 +66,29 @@
         "toggle-tool": {
           "type": "boolean",
           "title": "Toggle tool",
-          "description": "A boolean configuration value tool"
+          "description": "A boolean configuration value tool",
+          "canBeDisabled": true,
+          "defaultEnabledValue": false,
+          "isCritical": false,
+          "default": true
         },
         "text-tool": {
           "type": "string",
           "title": "Text tool (String)",
           "description": "A text configuration value tool",
+          "canBeDisabled": true,
+          "defaultEnabledValue": false,
+          "isCritical": true,
           "default": " String config value",
           "hint": "String config value"
         },
-        "enum-tool-floating-point": {
+        "enum-tool": {
           "type": "string",
           "title": "Enum tool",
+          "description": "An enum configuration value tool",
+          "canBeDisabled": true,
+          "defaultEnabledValue": false,
+          "isCritical": true,
           "default": "Second Option Value",
           "enum": [
             "First Option Value",

--- a/samples/android/src/main/assets/dev-tools.yml
+++ b/samples/android/src/main/assets/dev-tools.yml
@@ -2,7 +2,7 @@
 ## Boolean
 ##############################
 
-yml-toggle-tool: !toggle {
+toggle-tool: !toggle {
   title: "Toggle tool",
   description: "A boolean configuration value tool",
   canBeDisabled: true,
@@ -15,7 +15,7 @@ yml-toggle-tool: !toggle {
 ## String
 ##############################
 
-yml-text-tool: !text {
+text-tool: !text {
   title: "Text tool (String)",
   description: "A text configuration value tool",
   canBeDisabled: true,
@@ -29,7 +29,7 @@ yml-text-tool: !text {
 ## Integer
 ##############################
 
-yml-text-tool-integer: !text {
+text-tool-integer: !text {
   title: "Text tool (Integer)",
   description: "An integer number configuration value tool",
   canBeDisabled: true,
@@ -43,7 +43,7 @@ yml-text-tool-integer: !text {
 ## Floating point
 ##############################
 
-yml-text-tool-floating-point: !text {
+text-tool-floating-point: !text {
   title: "Text tool (Floating point)",
   description: "A floating-point number configuration value tool",
   canBeDisabled: true,
@@ -57,7 +57,7 @@ yml-text-tool-floating-point: !text {
 ## Time
 ##############################
 
-yml-time-tool: !time {
+time-tool: !time {
   title: "Time tool",
   description: "A time configuration value tool",
   canBeDisabled: true,
@@ -74,7 +74,7 @@ yml-time-tool: !time {
 ## Enum
 ##############################
 
-yml-enum-tool: !enum {
+enum-tool: !enum {
   title: "Enum tool",
   description: "An enum configuration value tool",
   canBeDisabled: true,
@@ -89,7 +89,7 @@ yml-enum-tool: !enum {
   }
 }
 
-yml-enum-custom-options-provider-tool: !enum {
+enum-custom-options-provider-tool: !enum {
   title: "Enum tool [Custom Provider]",
   description: "An enum configuration value tool with a custom options provider",
   canBeDisabled: true,
@@ -106,17 +106,17 @@ yml-enum-custom-options-provider-tool: !enum {
 ## Group
 ##############################
 
-yml-tools-group: !group {
+tools-group: !group {
   title: "Tools group",
   tools: {
-    yml-toggle-tool: !toggle {
+    toggle-tool: !toggle {
       title: "Toggle tool",
       description: "A boolean configuration value tool",
       canBeDisabled: true,
       defaultEnabledValue: false,
       isCritical: false
     },
-    yml-text-tool: !text {
+    text-tool: !text {
       title: "Text tool (String)",
       description: "A text configuration value tool",
       canBeDisabled: true,
@@ -125,7 +125,7 @@ yml-tools-group: !group {
       default: "Here can go any text value",
       hint: "String config value"
     },
-    yml-time-tool: !time {
+    time-tool: !time {
       title: "Time tool",
       description: "A time configuration value tool",
       canBeDisabled: true,
@@ -137,7 +137,7 @@ yml-tools-group: !group {
       seconds: 4,
       milliseconds: 5,
     },
-    yml-enum-tool: !enum {
+    enum-tool: !enum {
       title: "Enum tool",
       description: "An enum configuration value tool",
       canBeDisabled: true,

--- a/samples/android/src/main/assets/dev-tools.yml
+++ b/samples/android/src/main/assets/dev-tools.yml
@@ -2,7 +2,7 @@
 ## Boolean
 ##############################
 
-toggle-tool: !toggle {
+yml-toggle-tool: !toggle {
   title: "Toggle tool",
   description: "A boolean configuration value tool",
   canBeDisabled: true,
@@ -14,13 +14,13 @@ toggle-tool: !toggle {
 ## String
 ##############################
 
-text-tool: !text {
+yml-text-tool: !text {
   title: "Text tool (String)",
   description: "A text configuration value tool",
   canBeDisabled: true,
   defaultEnabledValue: false,
   isCritical: false,
-  defaultValue: "Here can go any text value",
+  default: "Here can go any text value",
   hint: "String config value"
 }
 
@@ -28,13 +28,13 @@ text-tool: !text {
 ## Integer
 ##############################
 
-text-tool-integer: !text {
+yml-text-tool-integer: !text {
   title: "Text tool (Integer)",
   description: "An integer number configuration value tool",
   canBeDisabled: true,
   defaultEnabledValue: false,
   isCritical: true,
-  defaultValue: 3,
+  default: 3,
   hint: "Integer number config value"
 }
 
@@ -42,13 +42,13 @@ text-tool-integer: !text {
 ## Floating point
 ##############################
 
-text-tool-floating-point: !text {
+yml-text-tool-floating-point: !text {
   title: "Text tool (Floating point)",
   description: "A floating-point number configuration value tool",
   canBeDisabled: true,
   defaultEnabledValue: false,
   isCritical: false,
-  defaultValue: 3.4,
+  default: 3.4,
   hint: "Floating point number config value"
 }
 
@@ -56,7 +56,7 @@ text-tool-floating-point: !text {
 ## Time
 ##############################
 
-time-tool: !time {
+yml-time-tool: !time {
   title: "Time tool",
   description: "A time configuration value tool",
   canBeDisabled: true,
@@ -73,7 +73,7 @@ time-tool: !time {
 ## Enum
 ##############################
 
-enum-tool: !enum {
+yml-enum-tool: !enum {
   title: "Enum tool",
   description: "An enum configuration value tool",
   canBeDisabled: true,
@@ -88,7 +88,7 @@ enum-tool: !enum {
   }
 }
 
-enum-custom-options-provider-tool: !enum {
+yml-enum-custom-options-provider-tool: !enum {
   title: "Enum tool [Custom Provider]",
   description: "An enum configuration value tool with a custom options provider",
   canBeDisabled: true,
@@ -105,26 +105,26 @@ enum-custom-options-provider-tool: !enum {
 ## Group
 ##############################
 
-tools-group: !group {
+yml-tools-group: !group {
   title: "Tools group",
   tools: {
-    toggle-tool: !toggle {
+    yml-toggle-tool: !toggle {
       title: "Toggle tool",
       description: "A boolean configuration value tool",
       canBeDisabled: true,
       defaultEnabledValue: false,
       isCritical: false
     },
-    text-tool: !text {
+    yml-text-tool: !text {
       title: "Text tool (String)",
       description: "A text configuration value tool",
       canBeDisabled: true,
       defaultEnabledValue: false,
       isCritical: true,
-      defaultValue: "Here can go any text value",
+      default: "Here can go any text value",
       hint: "String config value"
     },
-    time-tool: !time {
+    yml-time-tool: !time {
       title: "Time tool",
       description: "A time configuration value tool",
       canBeDisabled: true,
@@ -136,7 +136,7 @@ tools-group: !group {
       seconds: 4,
       milliseconds: 5,
     },
-    enum-tool: !enum {
+    yml-enum-tool: !enum {
       title: "Enum tool",
       description: "An enum configuration value tool",
       canBeDisabled: true,

--- a/samples/android/src/main/assets/dev-tools.yml
+++ b/samples/android/src/main/assets/dev-tools.yml
@@ -153,3 +153,4 @@ yml-tools-group: !group {
     }
   }
 }
+

--- a/samples/android/src/main/assets/dev-tools.yml
+++ b/samples/android/src/main/assets/dev-tools.yml
@@ -7,7 +7,8 @@ yml-toggle-tool: !toggle {
   description: "A boolean configuration value tool",
   canBeDisabled: true,
   defaultEnabledValue: false,
-  isCritical: true
+  isCritical: true,
+  default: true
 }
 
 ##############################

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/CustomToolsSource.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/CustomToolsSource.kt
@@ -1,0 +1,25 @@
+package com.maximbircu.devtools
+
+import com.maximbircu.devtools.common.core.DevTool
+import com.maximbircu.devtools.common.core.reader.DevToolsReader
+import com.maximbircu.devtools.common.core.reader.DevToolsSource
+import com.maximbircu.devtools.customtool.MyCustomTool
+
+val myCustomTools: Map<String, DevTool<*>> = mapOf(
+    "my-custom-tool" to MyCustomTool().apply {
+        title = "Custom tool"
+        description = "A custom dev tool implemented inside the library consumer"
+        canBeDisabled = true
+        defaultEnabledValue = false
+    }
+)
+
+class MyCustomDevToolsSource : DevToolsSource {
+    override fun getReader(): DevToolsReader {
+        return object : DevToolsReader {
+            override fun getDevTools(): Map<String, DevTool<*>> {
+                return myCustomTools
+            }
+        }
+    }
+}

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/MemoryDevToolsProvider.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/MemoryDevToolsProvider.kt
@@ -12,7 +12,7 @@ import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
 object MemoryDevToolsProvider {
     val tools: Map<String, DevTool<*>>
         get() = mapOf(
-            "toggle-tool" to ToggleTool(defaultValue = false).apply {
+            "toggle-tool" to ToggleTool(default = false).apply {
                 title = "Toggle tool"
                 description = "A boolean configuration value dev tool"
                 canBeDisabled = true
@@ -21,7 +21,7 @@ object MemoryDevToolsProvider {
             },
 
             "text-tool" to TextTool(
-                defaultValue = "Here can go any text value",
+                default = "Here can go any text value",
                 hint = "String config value"
             ).apply {
                 title = "Text tool (String)"
@@ -31,7 +31,7 @@ object MemoryDevToolsProvider {
                 isCritical = false
             },
             "text-tool-integer" to TextTool(
-                defaultValue = 3,
+                default = 3,
                 hint = "Integer number config value"
             ).apply {
                 title = "Text tool (Integer)"
@@ -41,7 +41,7 @@ object MemoryDevToolsProvider {
                 isCritical = true
             },
             "text-tool-float" to TextTool(
-                defaultValue = 3.4f,
+                default = 3.4f,
                 hint = "Floating point number config value"
             ).apply {
                 title = "Text tool (Floating point)"
@@ -98,7 +98,7 @@ object MemoryDevToolsProvider {
 
             "tools-group" to GroupTool(
                 tools = mapOf(
-                    "toggle-tool" to ToggleTool(defaultValue = false).apply {
+                    "toggle-tool" to ToggleTool(default = false).apply {
                         title = "Toggle tool"
                         description = "A boolean configuration value dev tool"
                         canBeDisabled = true
@@ -106,7 +106,7 @@ object MemoryDevToolsProvider {
                         isCritical = false
                     },
                     "text-tool" to TextTool(
-                        defaultValue = "Here can go any text value",
+                        default = "Here can go any text value",
                         hint = "String config value"
                     ).apply {
                         title = "Text tool (String)"

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/SampleApplication.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/SampleApplication.kt
@@ -2,11 +2,14 @@ package com.maximbircu.devtools
 
 import android.app.Application
 import com.maximbircu.devtools.MemoryDevToolsProvider.tools
+import com.maximbircu.devtools.android.DevToolsViewRegistry
 import com.maximbircu.devtools.android.readers.json
 import com.maximbircu.devtools.android.readers.yaml
 import com.maximbircu.devtools.common.DevTools
 import com.maximbircu.devtools.common.readers.DevToolsSources
 import com.maximbircu.devtools.common.readers.memory
+import com.maximbircu.devtools.customtool.MyCustomTool
+import com.maximbircu.devtools.customtool.MyCustomToolLayout
 
 class SampleApplication : Application() {
     lateinit var memoryDevTools: DevTools private set
@@ -23,13 +26,23 @@ class SampleApplication : Application() {
         super.onCreate()
         application = this
 
+        // Register MyCustomTool
+        DevToolsViewRegistry.register(MyCustomTool::class) { MyCustomToolLayout(it) }
+
         val memorySource = DevToolsSources.memory(tools)
         val ymlSource = DevToolsSources.yaml(assets, "dev-tools.yml")
         val jsonSource = DevToolsSources.json(assets, "dev-tools.json")
+        val customSource = MyCustomDevToolsSource()
 
-        memoryDevTools = DevTools.create("MEMORY", memorySource)
-        yamlDevTools = DevTools.create("YAML", ymlSource)
-        jsonDevTools = DevTools.create("JSON", jsonSource)
-        combinedDevTools = DevTools.create("COMBINED", memorySource, ymlSource, jsonSource)
+        memoryDevTools = DevTools.create("MEMORY", memorySource, customSource)
+        yamlDevTools = DevTools.create("YAML", ymlSource, customSource)
+        jsonDevTools = DevTools.create("JSON", jsonSource, customSource)
+        combinedDevTools = DevTools.create(
+            "COMBINED",
+            memorySource,
+            ymlSource,
+            jsonSource,
+            customSource
+        )
     }
 }

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/SampleApplication.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/SampleApplication.kt
@@ -22,6 +22,7 @@ class SampleApplication : Application() {
             private set
     }
 
+    @Suppress("LongMethod")
     override fun onCreate() {
         super.onCreate()
         application = this

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/customtool/MyCustomTool.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/customtool/MyCustomTool.kt
@@ -1,0 +1,14 @@
+package com.maximbircu.devtools.customtool
+
+import com.maximbircu.devtools.common.core.DevTool
+import com.maximbircu.devtools.common.core.ToolStore
+
+class MyCustomTool : DevTool<Boolean>() {
+    override val store: ToolStore<Boolean> = MyCustomToolStore(this)
+
+    override fun getDefaultValue(): Boolean {
+        return false // Suppose that I want the default value to always be true.
+    }
+}
+
+

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/customtool/MyCustomTool.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/customtool/MyCustomTool.kt
@@ -10,5 +10,3 @@ class MyCustomTool : DevTool<Boolean>() {
         return false // Suppose that I want the default value to always be true.
     }
 }
-
-

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/customtool/MyCustomToolLayout.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/customtool/MyCustomToolLayout.kt
@@ -1,0 +1,15 @@
+package com.maximbircu.devtools.customtool
+
+import android.content.Context
+import com.maximbircu.devtools.R
+import com.maximbircu.devtools.android.presentation.tool.DevToolLayout
+import kotlinx.android.synthetic.main.layout_my_custom_tool.view.checkbox
+
+class MyCustomToolLayout(context: Context) : DevToolLayout<MyCustomTool>(context) {
+    override val layoutRes: Int get() = R.layout.layout_my_custom_tool
+
+    override fun onBind(tool: MyCustomTool) {
+        checkbox.isChecked = tool.value
+        checkbox.setOnCheckedChangeListener { _, isChecked -> tool.value = isChecked }
+    }
+}

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/customtool/MyCustomToolStore.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/customtool/MyCustomToolStore.kt
@@ -1,5 +1,6 @@
 package com.maximbircu.devtools.customtool
 
+import android.annotation.SuppressLint
 import android.content.Context
 import com.maximbircu.devtools.SampleApplication
 import com.maximbircu.devtools.common.core.ToolStore
@@ -9,6 +10,7 @@ private val sharedPrefs = SampleApplication.application.getSharedPreferences(
     Context.MODE_PRIVATE
 )
 
+@SuppressLint("ApplySharedPref")
 class MyCustomToolStore(private val tool: MyCustomTool): ToolStore<Boolean> {
     override var isEnabled: Boolean
         get() = sharedPrefs.getBoolean("is_enabled_${tool.key}", tool.defaultEnabledValue)

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/customtool/MyCustomToolStore.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/customtool/MyCustomToolStore.kt
@@ -1,0 +1,20 @@
+package com.maximbircu.devtools.customtool
+
+import android.content.Context
+import com.maximbircu.devtools.SampleApplication
+import com.maximbircu.devtools.common.core.ToolStore
+
+private val sharedPrefs = SampleApplication.application.getSharedPreferences(
+    "MY_CUSTOM_TOOL_STORE",
+    Context.MODE_PRIVATE
+)
+
+class MyCustomToolStore(private val tool: MyCustomTool): ToolStore<Boolean> {
+    override var isEnabled: Boolean
+        get() = sharedPrefs.getBoolean("is_enabled_${tool.key}", tool.defaultEnabledValue)
+        set(value) { sharedPrefs.edit().putBoolean("is_enabled_${tool.key}", value).commit() }
+
+    override var value: Boolean
+        get() = sharedPrefs.getBoolean(tool.key, tool.getDefaultValue())
+        set(value) { sharedPrefs.edit().putBoolean(tool.key, value).commit() }
+}

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/customtool/MyCustomToolStore.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/customtool/MyCustomToolStore.kt
@@ -11,7 +11,7 @@ private val sharedPrefs = SampleApplication.application.getSharedPreferences(
 )
 
 @SuppressLint("ApplySharedPref")
-class MyCustomToolStore(private val tool: MyCustomTool): ToolStore<Boolean> {
+class MyCustomToolStore(private val tool: MyCustomTool) : ToolStore<Boolean> {
     override var isEnabled: Boolean
         get() = sharedPrefs.getBoolean("is_enabled_${tool.key}", tool.defaultEnabledValue)
         set(value) { sharedPrefs.edit().putBoolean("is_enabled_${tool.key}", value).commit() }

--- a/samples/android/src/main/res/layout/layout_my_custom_tool.xml
+++ b/samples/android/src/main/res/layout/layout_my_custom_tool.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CheckBox xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/checkbox"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/custom_tool_checkbox_label"
+    />

--- a/samples/android/src/main/res/values/strings.xml
+++ b/samples/android/src/main/res/values/strings.xml
@@ -9,4 +9,7 @@
     <string name="yaml_source_tools_button_text">yaml</string>
     <string name="json_schema_source_tools_button_text">Json schema</string>
     <string name="combined_source_tools_button_text">Combined</string>
+
+    <!-- Custom dev tool -->
+    <string name="custom_tool_checkbox_label">Is enabled</string>
 </resources>


### PR DESCRIPTION
Closes: #40 

- [x] Changelog <!-- Check this if you updated the changelog file  -->
- [x] Documentation (Readme) <!-- Check this if you updated the  documentation  -->

### What has been done
1. Cover the whole library with documentation, check [README](https://github.com/maximbircu/devtools-library/blob/40-add-api-documentation/README.md);
2. Add library extension Android samples;
3. Remove redundant `yml-` prefix;
4. Replace `defaultValue` with `default` everywhere to make the API consistent.

### How to test
Make sure the [library API docs](https://github.com/maximbircu/devtools-library/blob/40-add-api-documentation/README.md) are accessible, straight forward, and concise.
