### PR TITLE
Hide enable/disable checkbox for group tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog
 =========
 
 ## Version 1.0.0 *(In development)*
+Issue: [#49](https://github.com/maximbircu/devtools-library/issues/49)
+- Hide enable/disable the checkbox for group tools
+
 Issue: [#40](https://github.com/maximbircu/devtools-library/issues/40)
 - Cover the whole library with documentation, check README;
 - Add library extension Android samples;

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenter.kt
@@ -3,6 +3,7 @@ package com.maximbircu.devtools.common.presentation.tool
 import com.maximbircu.devtools.common.core.DevTool
 import com.maximbircu.devtools.common.core.mvp.BasePresenter
 import com.maximbircu.devtools.common.core.mvp.Presenter
+import com.maximbircu.devtools.common.presentation.tools.group.GroupTool
 
 /**
  * Encapsulates common [DevTool] context menu business logic.
@@ -93,7 +94,7 @@ private class DevToolPresenterImpl(
     }
 
     private fun updateToolEnableToggleVisibility() {
-        if (tool.canBeDisabled) {
+        if (tool.canBeDisabled && tool !is GroupTool) {
             view.showEnableToggle()
         } else {
             view.hideEnableToggle()

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolView.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolView.kt
@@ -1,13 +1,12 @@
 package com.maximbircu.devtools.common.presentation.tools.group
 
 import com.maximbircu.devtools.common.core.DevTool
-import com.maximbircu.devtools.common.core.mvp.BaseView
 import com.maximbircu.devtools.common.presentation.tool.DevToolView
 
 /**
  * Presents a group of devtools to the user.
  */
-interface GroupToolView : BaseView {
+interface GroupToolView : DevToolView {
     /**
      * Should return the configuration screen devtools views that are displayed by the group.
      */

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenterImplTest.kt
@@ -2,6 +2,7 @@ package com.maximbircu.devtools.common.presentation.tool
 
 import com.maximbircu.devtools.common.core.createTool
 import com.maximbircu.devtools.common.mvp.BasePresenterTest
+import com.maximbircu.devtools.common.presentation.tools.group.GroupTool
 import com.maximbircu.devtools.common.presentation.tools.text.TextTool
 import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
 import com.maximbircu.devtools.common.utils.mockk
@@ -42,6 +43,15 @@ class DevToolPresenterImplTest : BasePresenterTest<DevToolView, DevToolPresenter
     @Test
     fun `hides enable toggle if tool can not be disabled`() {
         val tool: ToggleTool = createTool { ::canBeDisabled returns false }
+
+        presenter.onToolBind(tool)
+
+        verify { view.hideEnableToggle() }
+    }
+
+    @Test
+    fun `hides enable toggle for a group tool even if it can be disabled `() {
+        val tool: GroupTool = createTool { ::canBeDisabled returns true }
 
         presenter.onToolBind(tool)
 


### PR DESCRIPTION
Closes: #49 

- [x] Unit tests  <!-- Check this if you covered your code with unit tests -->
- [x] Changelog <!-- Check this if you updated the changelog file  -->

### What has been done
 Hide enable/disable the checkbox for group tools

### How to test
1. Go to any configuration file, i.e. YAML config file
1. Find the group tool
1. Try to add canBeDisabled: true property
1. Run the sample app
1. Find the Group Tool you've updated

Expected
The enable checkbox should not be present

Actual
The enable checkbox ist present