### PR TITLE
Fix compact and extended enum option selector visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog
 =========
 
 ## Version 1.0.0 *(In development)*
+Issue: [#50](https://github.com/maximbircu/devtools-library/issues/50)
+- Hide compact view when the value itself is displayed and vice-versa
+
 Issue: [#49](https://github.com/maximbircu/devtools-library/issues/49)
 - Hide enable/disable the checkbox for group tools
 

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enum/EnumToolLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enum/EnumToolLayout.kt
@@ -2,16 +2,17 @@ package com.maximbircu.devtools.android.presentation.tools.enum
 
 import android.content.Context
 import com.maximbircu.devtools.android.R
+import com.maximbircu.devtools.android.extensions.hide
 import com.maximbircu.devtools.android.extensions.setOnClickListener
+import com.maximbircu.devtools.android.extensions.show
 import com.maximbircu.devtools.android.presentation.tool.DevToolLayout
-import com.maximbircu.devtools.android.presentation.tools.enum.selectors.chips.EnumToolChipsOptionSelectorLayout
 import com.maximbircu.devtools.android.presentation.tools.enum.selectors.dialog.EnumToolOptionSelectorDialog
 import com.maximbircu.devtools.common.presentation.tools.enum.EnumTool
 import com.maximbircu.devtools.common.presentation.tools.enum.EnumToolPresenter
 import com.maximbircu.devtools.common.presentation.tools.enum.EnumToolView
 import kotlinx.android.synthetic.main.layout_dev_tool.view.devToolCard
+import kotlinx.android.synthetic.main.layout_enum_tool.view.chipsSelector
 import kotlinx.android.synthetic.main.layout_enum_tool.view.currentValue
-import kotlinx.android.synthetic.main.layout_enum_tool.view.selectorContainer
 
 class EnumToolLayout(context: Context) : DevToolLayout<EnumTool>(context), EnumToolView {
     private val presenter = EnumToolPresenter.create(this)
@@ -20,14 +21,18 @@ class EnumToolLayout(context: Context) : DevToolLayout<EnumTool>(context), EnumT
     override fun onBind(tool: EnumTool) = presenter.onToolBind(tool)
 
     override fun showCompactOptionsSelector(tool: EnumTool, onNewOptionSelected: (String) -> Unit) {
-        selectorContainer.removeAllViews()
-        val chipsSelector = EnumToolChipsOptionSelectorLayout(context, tool, onNewOptionSelected)
-        selectorContainer.addView(chipsSelector)
+        chipsSelector.show()
+        chipsSelector.bind(tool, onNewOptionSelected)
     }
 
     override fun showConfigurationValue(value: String) {
+        currentValue.show()
         currentValue.text = value
         devToolCard.setOnClickListener(presenter::onToolClick)
+    }
+
+    override fun hideConfigurationValue() {
+        currentValue.hide()
     }
 
     override fun showOptionSelectorDialog(tool: EnumTool, onNewOptionSelected: (String) -> Unit) {
@@ -38,5 +43,10 @@ class EnumToolLayout(context: Context) : DevToolLayout<EnumTool>(context), EnumT
             presenter::onNegativeButtonClick,
             onNewOptionSelected
         ).show()
+    }
+
+    override fun hideCompactOptionsSelector() {
+        chipsSelector.hide()
+        devToolCard.setOnClickListener(null)
     }
 }

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enum/selectors/chips/EnumToolChipsOptionSelectorLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enum/selectors/chips/EnumToolChipsOptionSelectorLayout.kt
@@ -1,7 +1,7 @@
 package com.maximbircu.devtools.android.presentation.tools.enum.selectors.chips
 
-import android.annotation.SuppressLint
 import android.content.Context
+import android.util.AttributeSet
 import android.view.ViewTreeObserver.OnPreDrawListener
 import android.widget.FrameLayout
 import com.maximbircu.devtools.android.R
@@ -15,16 +15,22 @@ import kotlinx.android.synthetic.main.layout_enum_tool_chips_option_selector.vie
 import kotlinx.android.synthetic.main.layout_enum_tool_chips_option_selector.view.container
 import kotlinx.android.synthetic.main.layout_enum_tool_chips_option_selector.view.customValue
 
-@SuppressLint("ViewConstructor")
-class EnumToolChipsOptionSelectorLayout(
+class EnumToolChipsOptionSelectorLayout @JvmOverloads constructor(
     context: Context,
-    tool: EnumTool,
-    onOptionSelected: (String) -> Unit
-) : FrameLayout(context), EnumToolOptionSelectorView {
-    private val presenter = EnumToolOptionSelectorPresenter.create(this, onOptionSelected)
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr), EnumToolOptionSelectorView {
+    private lateinit var presenter: EnumToolOptionSelectorPresenter
 
     init {
         inflate(context, R.layout.layout_enum_tool_chips_option_selector, this)
+    }
+
+    fun bind(
+        tool: EnumTool,
+        onOptionSelected: (String) -> Unit
+    ) {
+        presenter = EnumToolOptionSelectorPresenter.create(this, onOptionSelected)
         presenter.onToolBind(tool)
         scrollToSelectedChipAfterPreDraw()
         chipGroup.setOnCheckedChangeListener(presenter::onOptionSelected)

--- a/devtools/android/src/main/res/layout/layout_enum_tool.xml
+++ b/devtools/android/src/main/res/layout/layout_enum_tool.xml
@@ -4,8 +4,8 @@
     android:layout_height="wrap_content"
     android:theme="@style/Theme.DevTools"
     >
-    <FrameLayout
-        android:id="@+id/selectorContainer"
+    <com.maximbircu.devtools.android.presentation.tools.enum.selectors.chips.EnumToolChipsOptionSelectorLayout
+        android:id="@+id/chipsSelector"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         />

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolPresenter.kt
@@ -57,8 +57,10 @@ private class EnumToolPresenterImpl(
         this.dialogSelectedValue = tool.value
         if (isCompactMode) {
             view.showCompactOptionsSelector(tool) { tool.value = it }
+            view.hideConfigurationValue()
         } else {
             view.showConfigurationValue(tool.value)
+            view.hideCompactOptionsSelector()
         }
     }
 

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolView.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolView.kt
@@ -15,6 +15,12 @@ interface EnumToolView : BaseView {
     fun showConfigurationValue(value: String)
 
     /**
+     * Should hide the configuration value because the number of options is small enough to present
+     * them inside a compact option selector.
+     */
+    fun hideConfigurationValue()
+
+    /**
      * Should present a compact option selector aka a single choice short list of selectable chips
      * or radio buttons.
      *
@@ -22,6 +28,12 @@ interface EnumToolView : BaseView {
      * @param onNewOptionSelected should be invoked whenever a new option is selected by the user
      */
     fun showCompactOptionsSelector(tool: EnumTool, onNewOptionSelected: (String) -> Unit)
+
+    /**
+     * Should hide the compact options selector because the number of options is too big and should
+     * be presented in a separate view, i.e. option selector dialog.
+     */
+    fun hideCompactOptionsSelector()
 
     /**
      * Should present an option selector in for of a scrollable single choice selectable items

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolPresenterImplTest.kt
@@ -24,12 +24,30 @@ class EnumToolPresenterImplTest : BasePresenterTest<EnumToolView, EnumToolPresen
     }
 
     @Test
+    fun `hides configuration value if options size is smaller than 7`() {
+        val tool: EnumTool = createCompactEnumTool()
+
+        presenter.onToolBind(tool)
+
+        verify { view.hideConfigurationValue() }
+    }
+
+    @Test
     fun `shows configuration value if options size is bigger than 6`() {
         val tool: EnumTool = createExtendedEnumTool()
 
         presenter.onToolBind(tool)
 
         verify { view.showConfigurationValue("Second Option Value") }
+    }
+
+    @Test
+    fun `hides compact option selector if options size is bigger than 6`() {
+        val tool: EnumTool = createExtendedEnumTool()
+
+        presenter.onToolBind(tool)
+
+        verify { view.hideCompactOptionsSelector() }
     }
 
     @Test


### PR DESCRIPTION
Closes: #50 

- [x] Unit tests  <!-- Check this if you covered your code with unit tests -->
- [x] Changelog <!-- Check this if you updated the changelog file  -->

### What has been done
Hide compact view when the value itself is displayed and vice-versa

### How to test
1. Open the sample app
2. Select any source, i.e. YAML
3. Scroll the list down, and up several times
4. Find any enum tool

**Expected**
All enum tools show the compact or extend options selector.

**Actual**
Both options selectors are visible and overlapped.