### PR TITLE
Revert "Fix compact and extended enum option selector visibility"

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check branch name and commit messages style
         uses: maximbircu/pull-request-checkstyle@v1.0.0
         with:
-          branch-name-regex: '\d+(-([a-z])+)+'
+          branch-name-regex: '^(revert-\d+-)?\d+(-([a-z])+)+'
           commit-message-title-regex: '^[A-Z].*'
 
   android-checkstyle:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog
 =========
 
 ## Version 1.0.0 *(In development)*
+Issue: [#50](https://github.com/maximbircu/devtools-library/issues/50)	
+- Use same container for both compact and current value views
+
 Issue: [#49](https://github.com/maximbircu/devtools-library/issues/49)
 - Hide enable/disable the checkbox for group tools
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@ Changelog
 =========
 
 ## Version 1.0.0 *(In development)*
-Issue: [#50](https://github.com/maximbircu/devtools-library/issues/50)
-- Hide compact view when the value itself is displayed and vice-versa
-
 Issue: [#49](https://github.com/maximbircu/devtools-library/issues/49)
 - Hide enable/disable the checkbox for group tools
 

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enum/EnumToolLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enum/EnumToolLayout.kt
@@ -1,6 +1,8 @@
 package com.maximbircu.devtools.android.presentation.tools.enum
 
 import android.content.Context
+import android.view.View
+import android.widget.TextView
 import com.maximbircu.devtools.android.R
 import com.maximbircu.devtools.android.extensions.setOnClickListener
 import com.maximbircu.devtools.android.presentation.tool.DevToolLayout
@@ -10,8 +12,7 @@ import com.maximbircu.devtools.common.presentation.tools.enum.EnumTool
 import com.maximbircu.devtools.common.presentation.tools.enum.EnumToolPresenter
 import com.maximbircu.devtools.common.presentation.tools.enum.EnumToolView
 import kotlinx.android.synthetic.main.layout_dev_tool.view.devToolCard
-import kotlinx.android.synthetic.main.layout_enum_tool.view.currentValue
-import kotlinx.android.synthetic.main.layout_enum_tool.view.selectorContainer
+import kotlinx.android.synthetic.main.layout_enum_tool.view.contentContainer
 
 class EnumToolLayout(context: Context) : DevToolLayout<EnumTool>(context), EnumToolView {
     private val presenter = EnumToolPresenter.create(this)
@@ -20,13 +21,11 @@ class EnumToolLayout(context: Context) : DevToolLayout<EnumTool>(context), EnumT
     override fun onBind(tool: EnumTool) = presenter.onToolBind(tool)
 
     override fun showCompactOptionsSelector(tool: EnumTool, onNewOptionSelected: (String) -> Unit) {
-        selectorContainer.removeAllViews()
-        val chipsSelector = EnumToolChipsOptionSelectorLayout(context, tool, onNewOptionSelected)
-        selectorContainer.addView(chipsSelector)
+        setContentView(EnumToolChipsOptionSelectorLayout(context, tool, onNewOptionSelected))
     }
 
     override fun showConfigurationValue(value: String) {
-        currentValue.text = value
+        setContentView(TextView(context).apply { text = value })
         devToolCard.setOnClickListener(presenter::onToolClick)
     }
 
@@ -38,5 +37,10 @@ class EnumToolLayout(context: Context) : DevToolLayout<EnumTool>(context), EnumT
             presenter::onNegativeButtonClick,
             onNewOptionSelected
         ).show()
+    }
+
+    private fun setContentView(contentView: View) {
+        contentContainer.removeAllViews()
+        contentContainer.addView(contentView)
     }
 }

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enum/EnumToolLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enum/EnumToolLayout.kt
@@ -2,17 +2,16 @@ package com.maximbircu.devtools.android.presentation.tools.enum
 
 import android.content.Context
 import com.maximbircu.devtools.android.R
-import com.maximbircu.devtools.android.extensions.hide
 import com.maximbircu.devtools.android.extensions.setOnClickListener
-import com.maximbircu.devtools.android.extensions.show
 import com.maximbircu.devtools.android.presentation.tool.DevToolLayout
+import com.maximbircu.devtools.android.presentation.tools.enum.selectors.chips.EnumToolChipsOptionSelectorLayout
 import com.maximbircu.devtools.android.presentation.tools.enum.selectors.dialog.EnumToolOptionSelectorDialog
 import com.maximbircu.devtools.common.presentation.tools.enum.EnumTool
 import com.maximbircu.devtools.common.presentation.tools.enum.EnumToolPresenter
 import com.maximbircu.devtools.common.presentation.tools.enum.EnumToolView
 import kotlinx.android.synthetic.main.layout_dev_tool.view.devToolCard
-import kotlinx.android.synthetic.main.layout_enum_tool.view.chipsSelector
 import kotlinx.android.synthetic.main.layout_enum_tool.view.currentValue
+import kotlinx.android.synthetic.main.layout_enum_tool.view.selectorContainer
 
 class EnumToolLayout(context: Context) : DevToolLayout<EnumTool>(context), EnumToolView {
     private val presenter = EnumToolPresenter.create(this)
@@ -21,18 +20,14 @@ class EnumToolLayout(context: Context) : DevToolLayout<EnumTool>(context), EnumT
     override fun onBind(tool: EnumTool) = presenter.onToolBind(tool)
 
     override fun showCompactOptionsSelector(tool: EnumTool, onNewOptionSelected: (String) -> Unit) {
-        chipsSelector.show()
-        chipsSelector.bind(tool, onNewOptionSelected)
+        selectorContainer.removeAllViews()
+        val chipsSelector = EnumToolChipsOptionSelectorLayout(context, tool, onNewOptionSelected)
+        selectorContainer.addView(chipsSelector)
     }
 
     override fun showConfigurationValue(value: String) {
-        currentValue.show()
         currentValue.text = value
         devToolCard.setOnClickListener(presenter::onToolClick)
-    }
-
-    override fun hideConfigurationValue() {
-        currentValue.hide()
     }
 
     override fun showOptionSelectorDialog(tool: EnumTool, onNewOptionSelected: (String) -> Unit) {
@@ -43,10 +38,5 @@ class EnumToolLayout(context: Context) : DevToolLayout<EnumTool>(context), EnumT
             presenter::onNegativeButtonClick,
             onNewOptionSelected
         ).show()
-    }
-
-    override fun hideCompactOptionsSelector() {
-        chipsSelector.hide()
-        devToolCard.setOnClickListener(null)
     }
 }

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enum/selectors/chips/EnumToolChipsOptionSelectorLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enum/selectors/chips/EnumToolChipsOptionSelectorLayout.kt
@@ -1,7 +1,7 @@
 package com.maximbircu.devtools.android.presentation.tools.enum.selectors.chips
 
+import android.annotation.SuppressLint
 import android.content.Context
-import android.util.AttributeSet
 import android.view.ViewTreeObserver.OnPreDrawListener
 import android.widget.FrameLayout
 import com.maximbircu.devtools.android.R
@@ -15,22 +15,16 @@ import kotlinx.android.synthetic.main.layout_enum_tool_chips_option_selector.vie
 import kotlinx.android.synthetic.main.layout_enum_tool_chips_option_selector.view.container
 import kotlinx.android.synthetic.main.layout_enum_tool_chips_option_selector.view.customValue
 
-class EnumToolChipsOptionSelectorLayout @JvmOverloads constructor(
+@SuppressLint("ViewConstructor")
+class EnumToolChipsOptionSelectorLayout(
     context: Context,
-    attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
-) : FrameLayout(context, attrs, defStyleAttr), EnumToolOptionSelectorView {
-    private lateinit var presenter: EnumToolOptionSelectorPresenter
+    tool: EnumTool,
+    onOptionSelected: (String) -> Unit
+) : FrameLayout(context), EnumToolOptionSelectorView {
+    private val presenter = EnumToolOptionSelectorPresenter.create(this, onOptionSelected)
 
     init {
         inflate(context, R.layout.layout_enum_tool_chips_option_selector, this)
-    }
-
-    fun bind(
-        tool: EnumTool,
-        onOptionSelected: (String) -> Unit
-    ) {
-        presenter = EnumToolOptionSelectorPresenter.create(this, onOptionSelected)
         presenter.onToolBind(tool)
         scrollToSelectedChipAfterPreDraw()
         chipGroup.setOnCheckedChangeListener(presenter::onOptionSelected)

--- a/devtools/android/src/main/res/layout/layout_enum_tool.xml
+++ b/devtools/android/src/main/res/layout/layout_enum_tool.xml
@@ -4,8 +4,8 @@
     android:layout_height="wrap_content"
     android:theme="@style/Theme.DevTools"
     >
-    <com.maximbircu.devtools.android.presentation.tools.enum.selectors.chips.EnumToolChipsOptionSelectorLayout
-        android:id="@+id/chipsSelector"
+    <FrameLayout
+        android:id="@+id/selectorContainer"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         />

--- a/devtools/android/src/main/res/layout/layout_enum_tool.xml
+++ b/devtools/android/src/main/res/layout/layout_enum_tool.xml
@@ -3,16 +3,5 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:theme="@style/Theme.DevTools"
-    >
-    <FrameLayout
-        android:id="@+id/selectorContainer"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        />
-
-    <TextView
-        android:id="@+id/currentValue"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        />
-</FrameLayout>
+    android:id="@+id/contentContainer"
+    />

--- a/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/readers/soruces/yaml/YamlDevToolsSourceTest.kt
+++ b/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/readers/soruces/yaml/YamlDevToolsSourceTest.kt
@@ -1,0 +1,28 @@
+package com.maximbircu.devtools.android.readers.soruces.yaml
+
+import com.maximbircu.devtools.android.BaseTest
+import com.maximbircu.devtools.android.utils.mockk
+import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
+import io.mockk.every
+import io.mockk.mockkConstructor
+import org.junit.Test
+import org.yaml.snakeyaml.Yaml
+import java.io.InputStream
+import kotlin.test.assertTrue
+
+class YamlDevToolsSourceTest : BaseTest() {
+    @Test
+    fun `test`() {
+        setUpYaml(mapOf(ToggleTool::class.java.name to "!toggle"))
+        val source = YamlDevToolsSource(mockk(relaxed = true), "".byteInputStream())
+
+        val reader = source.getReader()
+
+        assertTrue(reader is YamlDevToolsReader)
+    }
+
+    private fun setUpYaml(types: Map<String, String>) {
+        mockkConstructor(Yaml::class)
+        every { anyConstructed<Yaml>().load<Map<String, String>>(any<InputStream>()) } returns types
+    }
+}

--- a/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/readers/soruces/yaml/YamlDevToolsTypesRegistryImplTest.kt
+++ b/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/readers/soruces/yaml/YamlDevToolsTypesRegistryImplTest.kt
@@ -22,7 +22,7 @@ class YamlDevToolsTypesRegistryImplTest : BaseTest() {
         setUpConstructor(typeDescriptionSlot)
         setUpYaml(mapOf(ToggleTool::class.java.name to "!toggle"))
 
-        YamlDevToolsTypesRegistry.create("".trimIndent().byteInputStream())
+        YamlDevToolsTypesRegistry.create("".byteInputStream())
 
         assertEquals(ToggleTool::class.java, typeDescriptionSlot.captured.type)
         assertEquals("!toggle", typeDescriptionSlot.captured.tag.value)

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolPresenter.kt
@@ -57,10 +57,8 @@ private class EnumToolPresenterImpl(
         this.dialogSelectedValue = tool.value
         if (isCompactMode) {
             view.showCompactOptionsSelector(tool) { tool.value = it }
-            view.hideConfigurationValue()
         } else {
             view.showConfigurationValue(tool.value)
-            view.hideCompactOptionsSelector()
         }
     }
 

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolView.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolView.kt
@@ -15,12 +15,6 @@ interface EnumToolView : BaseView {
     fun showConfigurationValue(value: String)
 
     /**
-     * Should hide the configuration value because the number of options is small enough to present
-     * them inside a compact option selector.
-     */
-    fun hideConfigurationValue()
-
-    /**
      * Should present a compact option selector aka a single choice short list of selectable chips
      * or radio buttons.
      *
@@ -28,12 +22,6 @@ interface EnumToolView : BaseView {
      * @param onNewOptionSelected should be invoked whenever a new option is selected by the user
      */
     fun showCompactOptionsSelector(tool: EnumTool, onNewOptionSelected: (String) -> Unit)
-
-    /**
-     * Should hide the compact options selector because the number of options is too big and should
-     * be presented in a separate view, i.e. option selector dialog.
-     */
-    fun hideCompactOptionsSelector()
 
     /**
      * Should present an option selector in for of a scrollable single choice selectable items

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolPresenterImplTest.kt
@@ -24,30 +24,12 @@ class EnumToolPresenterImplTest : BasePresenterTest<EnumToolView, EnumToolPresen
     }
 
     @Test
-    fun `hides configuration value if options size is smaller than 7`() {
-        val tool: EnumTool = createCompactEnumTool()
-
-        presenter.onToolBind(tool)
-
-        verify { view.hideConfigurationValue() }
-    }
-
-    @Test
     fun `shows configuration value if options size is bigger than 6`() {
         val tool: EnumTool = createExtendedEnumTool()
 
         presenter.onToolBind(tool)
 
         verify { view.showConfigurationValue("Second Option Value") }
-    }
-
-    @Test
-    fun `hides compact option selector if options size is bigger than 6`() {
-        val tool: EnumTool = createExtendedEnumTool()
-
-        presenter.onToolBind(tool)
-
-        verify { view.hideCompactOptionsSelector() }
     }
 
     @Test

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolTest.kt
@@ -27,8 +27,11 @@ class EnumToolTest : BaseTest() {
         assertFailsWith(IllegalArgumentException::class) { tool.getDefaultValue() }
     }
 
-    private fun createTool(defaultValueKey: String?): EnumTool {
-        return EnumTool(defaultValueKey, optionsProvider = StubOptionsProvider())
+    private fun createTool(
+        defaultValueKey: String?,
+        optionsProvider: EnumOptionsProvider? = StubOptionsProvider()
+    ): EnumTool {
+        return EnumTool(defaultValueKey, false, optionsProvider)
     }
 
     private class StubOptionsProvider : EnumOptionsProvider {


### PR DESCRIPTION
Reverts maximbircu/devtools-library#52
Closes #50 

- [x] Changelog <!-- Check this if you updated the changelog file  -->

### What has been done
1. ~Hide compact view when the value itself is displayed and vice-versa~ Reverted this behavior
1. Seems that we should replace the view all the time, otherwise it will be recycled and this will introduce a weird checked change listeners behavior and a crash.

### How to test
1. Open the sample app
2. Select any source, i.e. YAML
3. Scroll the list down, and up several times
4. Find any enum tool

**Expected**
All enum tools show the compact or extend options selector.

**Actual**
Both options selectors are visible and overlapped.