### PR TITLE
Adjust the library docs after first release

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,7 +14,7 @@ In case your feature request is related to a problem then add a clear and concis
 <!-- Add a clear and concise description of the feature you want us to implement. -->
 
 ## Implementation details
-<!-- Add some impementation details in case you have. -->
+<!-- Add some implementation details in case you have. -->
 
 ## Consumer flow
 <!-- Add a step by step instruction of how to test the feature. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Closes: <!-- Add a link to the issue this PR relates to -->
 - [ ] Documentation (Readme) <!-- Check this if you updated the  documentation  -->
 
 ### What has been done
- 1. <!-- Write a detailed description about what changes your PR bings -->
+ 1. <!-- Write a detailed description about what changes your PR brings -->
  2. 
 
 ### Screenshots

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## Version 1.0.1 *(In development)*
 
+Issue: [#62](https://github.com/maximbircu/devtools-library/issues/62)	
+- Fix spelling mistakes in issues templates files
+- Add maven central badges and fill in the "Add the library dependency" section from the QuickStart docs;
+
 ## Version 1.0.0 06/05/2020
 Issue: [#58](https://github.com/maximbircu/devtools-library/issues/58)	
 - Update the Android library common module dependency for release configuration to 1.0.0

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![Platform](https://img.shields.io/badge/platform-Android%20%7C%20iOS-lightgrey?style=flat)
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.maximbircu/devtools-android/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.maximbircu/devtools-android)
+
 ![CI](https://github.com/maximbircu/devtools-library/workflows/CI/badge.svg?branch=master)
 [![codecov](https://codecov.io/gh/maximbircu/devtools-library/branch/master/graph/badge.svg?token=TP8XUCW2HB)](https://codecov.io/gh/maximbircu/devtools-library)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/maximbircu/devtools-library/blob/master/LICENSE.md)

--- a/documentation/quickstart/quick-start-android.md
+++ b/documentation/quickstart/quick-start-android.md
@@ -3,9 +3,21 @@
 # Quick start 
 
 1. **Add the library dependency**
-
-    TBA
-
+    * Configure the maven central repository
+        ```groovy
+        repositories {
+            mavenCentral()
+        }
+        ```
+    * Choose library version from [releases](https://github.com/maximbircu/devtools-library/releases) or [changelog](../../CHANGELOG.md)
+    * Latest version: [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.maximbircu/devtools-android/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.maximbircu/devtools-android)
+    * Add the library dependency
+      ```groovy
+      dependencies {
+          implementation "com.maximbircu:devtools-android:1.0.0"
+      }
+      ```
+      
 <br />
 
 2. **Add a configuration file**

--- a/documentation/quickstart/quick-start-android.md
+++ b/documentation/quickstart/quick-start-android.md
@@ -10,7 +10,7 @@
         }
         ```
     * Choose library version from [releases](https://github.com/maximbircu/devtools-library/releases) or [changelog](../../CHANGELOG.md)
-    * Latest version: [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.maximbircu/devtools-android/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.maximbircu/devtools-android)
+    * Latest version: [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.maximbircu/devtools-android/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.maximbircu/devtools-common)
     * Add the library dependency
       ```groovy
       dependencies {
@@ -25,7 +25,7 @@
     Currently, you can set up your app with dev tools directly from the code or using a [YAML](https://yaml.org/) or [JSON Schema Draft-07](https://json-schema.org/draft-07/json-schema-validation.html) configuration file.
     The example will be based on YML; however, using other sources is not hard. 
     
-    You can check the [supported dev tools](../documentation.md#supported-dev-tools) and [configuration sources](../documentation.md#configuration-sources) for more information.
+    You can check the [supported dev tools](../documentation.md#prebuilt-dev-tool-types) and [configuration sources](../documentation.md#configuration-sources) for more information.
     
     So, create a `dev-tools.yml` configuration file inside your app's `assets` directory.
     


### PR DESCRIPTION
Closes: <!-- Add a link to the issue this PR relates to -->

- [x] Changelog <!-- Check this if you updated the changelog file  -->
- [x] Documentation (Readme) <!-- Check this if you updated the  documentation  -->

### What has been done
 1. Adjust the "Add the library dependency" section from the QuickStart docs;
 2. Add maven central badge to the README file.

### How to test
Make sure the CI is ✅ 