### PR TITLE
Use `GITHUB_TOKEN` instead of GITHUB_ACCESS_TOKEN

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -9,7 +9,7 @@ jobs:
     name: Check pull request styling
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check branch name and commit messages style
         uses: maximbircu/pull-request-checkstyle@v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 ## Version 1.0.1 *(In development)*
 
+Issue: [#66](https://github.com/maximbircu/devtools-library/issues/66)
+- Replace the usage of GITHUB_ACCESS_TOKEN with the standard GITHUB_TOKEN secret
+
 Issue: [#62](https://github.com/maximbircu/devtools-library/issues/62)	
 - Fix spelling mistakes in issues templates files
 - Add maven central badges and fill in the "Add the library dependency" section from the QuickStart docs;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Changelog
 
 Issue: [#66](https://github.com/maximbircu/devtools-library/issues/66)
 - Replace the usage of GITHUB_ACCESS_TOKEN with the standard GITHUB_TOKEN secret
+- Update targetSdk to 30
+- Update material to 1.2.1
+- Update appcompat to 1.2.0
+- Update constraints layout to 2.1.0-alpha2
+- Update core-ktx to 1.3.2
+- Update snakeyaml to 1.27 
 
 Issue: [#62](https://github.com/maximbircu/devtools-library/issues/62)	
 - Fix spelling mistakes in issues templates files

--- a/devtools/android/build.gradle
+++ b/devtools/android/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // androidx
-    implementation "androidx.core:core-ktx:1.2.0"
+    implementation "androidx.core:core-ktx:1.3.2"
     implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.recyclerview:recyclerview:1.1.0"

--- a/devtools/android/build.gradle
+++ b/devtools/android/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.recyclerview:recyclerview:1.1.0"
-    implementation "androidx.constraintlayout:constraintlayout:2.0.0-beta4"
+    implementation "androidx.constraintlayout:constraintlayout:2.1.0-alpha2"
 
     // test
     testImplementation "org.jetbrains.kotlin:kotlin-test"

--- a/devtools/android/build.gradle
+++ b/devtools/android/build.gradle
@@ -59,7 +59,7 @@ dependencies {
 
     // androidx
     implementation "androidx.core:core-ktx:1.2.0"
-    implementation "androidx.appcompat:appcompat:1.1.0"
+    implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.constraintlayout:constraintlayout:2.0.0-beta4"

--- a/devtools/android/build.gradle
+++ b/devtools/android/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     debugApi(project(':devtools:common')) { transitive = true }
     releaseApi("com.maximbircu:devtools-common:1.0.0") { transitive = true }
 
-    implementation "org.yaml:snakeyaml:1.25"
+    implementation "org.yaml:snakeyaml:1.27"
     implementation "com.google.android.material:material:1.2.1"
 
     // kotlin

--- a/devtools/android/build.gradle
+++ b/devtools/android/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     releaseApi("com.maximbircu:devtools-common:1.0.0") { transitive = true }
 
     implementation "org.yaml:snakeyaml:1.25"
-    implementation "com.google.android.material:material:1.1.0"
+    implementation "com.google.android.material:material:1.2.1"
 
     // kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/devtools/android/build.gradle
+++ b/devtools/android/build.gradle
@@ -20,11 +20,11 @@ configureJacoco {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 29
+        targetSdkVersion 30
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'

--- a/devtools/common/build.gradle
+++ b/devtools/common/build.gradle
@@ -13,8 +13,7 @@ configurePublishing {
 }
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion 30
 
     buildTypes {
         release {

--- a/samples/android/build.gradle
+++ b/samples/android/build.gradle
@@ -5,12 +5,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "com.maximbircu.devtools"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 

--- a/samples/android/build.gradle
+++ b/samples/android/build.gradle
@@ -53,5 +53,5 @@ dependencies {
 
     // androidx
     implementation "androidx.appcompat:appcompat:1.2.0"
-    implementation "androidx.constraintlayout:constraintlayout:1.1.3"
+    implementation "androidx.constraintlayout:constraintlayout:2.0.4"
 }

--- a/samples/android/build.gradle
+++ b/samples/android/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-    implementation "com.google.android.material:material:1.1.0"
+    implementation "com.google.android.material:material:1.2.1"
     implementation 'com.google.code.gson:gson:2.8.6'
 
     // androidx

--- a/samples/android/build.gradle
+++ b/samples/android/build.gradle
@@ -52,6 +52,6 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
 
     // androidx
-    implementation "androidx.appcompat:appcompat:1.1.0"
+    implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
 }


### PR DESCRIPTION
Closes: #66 

- [ ] Unit tests  <!-- Check this if you covered your code with unit tests -->
- [x] Changelog <!-- Check this if you updated the changelog file  -->
- [ ] Documentation (Readme) <!-- Check this if you updated the  documentation  -->

### What has been done
- Replace `GITHUB_ACCESS_TOKEN` usage with [GITHUB_TOKEN](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow).
- Update targetSdk to 30
- Update material to 1.2.1
- Update appcompat to 1.2.0
- Update constraints layout to 2.1.0-alpha2
- Update core-ktx to 1.3.2
- Update snakeyaml to 1.27 

### How to test
Male sure the CI is ✅ 