### PR TITLE
Enable Dev Tool whenever the user tries to update it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 ## Version 1.0.1 *(In development)*
 
+Issue: [#68](https://github.com/maximbircu/devtools-library/issues/66)
+- Enable dev tool automatically whenever the user tries to update its configuration value
+
 Issue: [#66](https://github.com/maximbircu/devtools-library/issues/66)
 - Replace the usage of GITHUB_ACCESS_TOKEN with the standard GITHUB_TOKEN secret
 - Update targetSdk to 30

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tool/DevToolLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tool/DevToolLayout.kt
@@ -33,6 +33,7 @@ abstract class DevToolLayout<T : DevTool<*>>(
         binding.devToolContentContainerOverlay.setOnClickListener {
             binding.headerContainer.toolEnableToggle
                 .startAnimation(loadAnimation(context, R.anim.bounce))
+            presenter.onAttemptToEditToolConfigValue()
         }
     }
 

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenter.kt
@@ -37,6 +37,12 @@ interface DevToolPresenter : DevToolContextMenuPresenter {
     fun onToolBind(tool: DevTool<*>)
 
     /**
+     * Should be invoked as son as the user touches the input area of the dev tool trying to update
+     * the dev tool configuration value.
+     */
+    fun onAttemptToEditToolConfigValue()
+
+    /**
      * Should be called whenever the user toggles the tool enable toggle.
      */
     fun onToolEnableToggleUpdated(isEnabled: Boolean)
@@ -68,6 +74,12 @@ private class DevToolPresenterImpl(
         view.setTitle(tool.title)
         view.setToolEnableState(tool.isEnabled)
         updateToolEnableToggleVisibility()
+    }
+
+    override fun onAttemptToEditToolConfigValue() {
+        if (tool.canBeDisabled && !tool.isEnabled) {
+            onToolEnableToggleUpdated(true)
+        }
     }
 
     override fun onToolEnableToggleUpdated(isEnabled: Boolean) {

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenter.kt
@@ -37,7 +37,7 @@ interface DevToolPresenter : DevToolContextMenuPresenter {
     fun onToolBind(tool: DevTool<*>)
 
     /**
-     * Should be invoked as son as the user touches the input area of the dev tool trying to update
+     * Should be invoked as soon as the user touches the input area of the dev tool trying to update
      * the dev tool configuration value.
      */
     fun onAttemptToEditToolConfigValue()

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenterImplTest.kt
@@ -77,6 +77,20 @@ class DevToolPresenterImplTest : BasePresenterTest<DevToolView, DevToolPresenter
         verify { tool.isEnabled = true }
     }
 
+    @Test
+    fun `enables tool whenever the user tries update its configuration value`() {
+        val tool: TextTool = createTool {
+            ::isEnabled returns false
+            ::canBeDisabled returns true
+        }
+        presenter.onToolBind(tool)
+
+        presenter.onAttemptToEditToolConfigValue()
+
+        verify { tool.isEnabled = true }
+        verify { view.setToolEnableState(true) }
+    }
+
     // region Tool Context Menu
 
     @Test

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenterImplTest.kt
@@ -85,6 +85,7 @@ class DevToolPresenterImplTest : BasePresenterTest<DevToolView, DevToolPresenter
             ::canBeDisabled returns true
         }
         presenter.onToolBind(tool)
+        clearAllMocks(answers = false)
 
         presenter.onAttemptToEditToolConfigValue()
 
@@ -99,7 +100,7 @@ class DevToolPresenterImplTest : BasePresenterTest<DevToolView, DevToolPresenter
             ::canBeDisabled returns true
         }
         presenter.onToolBind(tool)
-        clearAllMocks(recordedCalls = true)
+        clearAllMocks(answers = false)
 
         presenter.onAttemptToEditToolConfigValue()
 
@@ -114,7 +115,7 @@ class DevToolPresenterImplTest : BasePresenterTest<DevToolView, DevToolPresenter
             ::canBeDisabled returns false
         }
         presenter.onToolBind(tool)
-        clearAllMocks(recordedCalls = true)
+        clearAllMocks(answers = false)
 
         presenter.onAttemptToEditToolConfigValue()
 
@@ -129,7 +130,7 @@ class DevToolPresenterImplTest : BasePresenterTest<DevToolView, DevToolPresenter
             ::canBeDisabled returns false
         }
         presenter.onToolBind(tool)
-        clearAllMocks(recordedCalls = true)
+        clearAllMocks(answers = false)
 
         presenter.onAttemptToEditToolConfigValue()
 

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tool/DevToolPresenterImplTest.kt
@@ -7,6 +7,7 @@ import com.maximbircu.devtools.common.presentation.tools.text.TextTool
 import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
 import com.maximbircu.devtools.common.utils.mockk
 import com.maximbircu.devtools.common.utils.returns
+import io.mockk.clearAllMocks
 import io.mockk.verify
 import kotlin.test.Test
 
@@ -78,7 +79,7 @@ class DevToolPresenterImplTest : BasePresenterTest<DevToolView, DevToolPresenter
     }
 
     @Test
-    fun `enables tool whenever the user tries update its configuration value`() {
+    fun `enables disabled tool when user tries to update it and the tool can be enabled`() {
         val tool: TextTool = createTool {
             ::isEnabled returns false
             ::canBeDisabled returns true
@@ -89,6 +90,51 @@ class DevToolPresenterImplTest : BasePresenterTest<DevToolView, DevToolPresenter
 
         verify { tool.isEnabled = true }
         verify { view.setToolEnableState(true) }
+    }
+
+    @Test
+    fun `doesn't enable enabled tool when user tires to update it`() {
+        val tool: TextTool = createTool {
+            ::isEnabled returns true
+            ::canBeDisabled returns true
+        }
+        presenter.onToolBind(tool)
+        clearAllMocks(recordedCalls = true)
+
+        presenter.onAttemptToEditToolConfigValue()
+
+        verify(exactly = 0) { tool.isEnabled = true }
+        verify(exactly = 0) { view.setToolEnableState(true) }
+    }
+
+    @Test
+    fun `doesn't enable a tool that can not be enabled when user tires to update it`() {
+        val tool: TextTool = createTool {
+            ::isEnabled returns true
+            ::canBeDisabled returns false
+        }
+        presenter.onToolBind(tool)
+        clearAllMocks(recordedCalls = true)
+
+        presenter.onAttemptToEditToolConfigValue()
+
+        verify(exactly = 0) { tool.isEnabled = true }
+        verify(exactly = 0) { view.setToolEnableState(true) }
+    }
+
+    @Test
+    fun `doesn't enable a disabled tool that can not be enabled when user tires to update it`() {
+        val tool: TextTool = createTool {
+            ::isEnabled returns false
+            ::canBeDisabled returns false
+        }
+        presenter.onToolBind(tool)
+        clearAllMocks(recordedCalls = true)
+
+        presenter.onAttemptToEditToolConfigValue()
+
+        verify(exactly = 0) { tool.isEnabled = true }
+        verify(exactly = 0) { view.setToolEnableState(true) }
     }
 
     // region Tool Context Menu


### PR DESCRIPTION
Closes: #68

- [x] Unit tests  <!-- Check this if you covered your code with unit tests -->
- [x] Changelog <!-- Check this if you updated the changelog file  -->
- [ ] Documentation (Readme) <!-- Check this if you updated the  documentation  -->

### What has been done
Added `DevToolPresenter#onAttemptToEditToolConfigValue` which should be invoked whenever the user touches the control area of any dev tool. Enabled the dev tool whenever this method gets invoked in case the dev tool enables able and it is not enabled already.

### Screenshots
<img src="https://user-images.githubusercontent.com/12527390/104823922-721f0780-5856-11eb-8910-3888887ad2d8.gif" width=200>

### How to test
u1

1. Open the dev tools screen for any source, i.e. YAML;
1. Touch the input area of any disabled dev tool;
1. Note that the tool became automatically enabled.
u2

1. Open the dev tools screen for any source, i.e. YAML;
1. Touch the input area of any enabled dev tool;
1. Make sure that you're able to edit the dev tool value.
