### PR TITLE
Implement discard changes dialog

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,3 +5,4 @@ coverage:
         target: auto
         threshold: 1%
         base: auto
+    patch: off

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -24,6 +24,10 @@ jobs:
       - name: SCM
         uses: actions/checkout@v2
 
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
       - name: Android lint
         uses: eskatos/gradle-command-action@v1
         with:
@@ -58,6 +62,10 @@ jobs:
       - name: SCM
         uses: actions/checkout@v2
 
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
       - name: Test
         uses: eskatos/gradle-command-action@v1
         with:
@@ -84,6 +92,10 @@ jobs:
       - name: SCM
         uses: actions/checkout@v2
 
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
       - name: Generate fat frramework
         uses: eskatos/gradle-command-action@v1
         with:
@@ -105,6 +117,10 @@ jobs:
     steps:
       - name: SCM
         uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
 
       - name: Assemble
         uses: eskatos/gradle-command-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ Changelog
 =========
 
 ## Version 1.0.1 *(In development)*
+Issue: [#73](https://github.com/maximbircu/devtools-library/issues/73)
+- Implemented a discard dialog - in case the user will try to leave the configuration screen with unsaved changes the screen will not close and a discard dialog will be displayed instead. The dialog will be closed and the unsaved changes discarded in case the user will hit the OK button.
+- Updated some libraries including kotlinx-serialization and migrated to AGP 7
+- Update targetSdkVersion to 31
+- Update to latest ktlint
+- Update to latest detekt
 
 Issue: [#12](https://github.com/maximbircu/devtools-library/issues/12)
 - Implement iOS YAML devtools reader

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = "1.3.72"
+    ext.kotlin_version = "1.5.21"
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 }
 
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "1.6.0"
+    id "io.gitlab.arturbosch.detekt" version "1.18.0-RC3"
 }
 
 apply from: 'gradle/detekt.gradle'
@@ -25,8 +25,6 @@ apply from: 'gradle/ktlint.gradle'
 apply from: 'gradle/jacoco.gradle'
 
 allprojects {
-    apply plugin: 'io.gitlab.arturbosch.detekt'
-
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
         kotlinOptions {
             allWarningsAsErrors = true

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
 buildscript {
     ext.kotlin_version = "1.5.21"
     repositories {
@@ -35,6 +37,11 @@ allprojects {
         google()
         jcenter()
         mavenCentral()
+    }
+
+    afterEvaluate {
+        def kmpExt = project.extensions.findByType(TypeOf.typeOf(KotlinMultiplatformExtension))
+        kmpExt?.sourceSets?.removeAll { it.name == "androidAndroidTestRelease" }
     }
 
     configurations.all {

--- a/devtools/android/build.gradle
+++ b/devtools/android/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 apply from: "$rootDir/gradle/publishing.gradle"
 
@@ -56,18 +55,18 @@ dependencies {
     releaseApi("com.maximbircu:devtools-common:1.0.0") { transitive = true }
 
     implementation "org.yaml:snakeyaml:1.27"
-    implementation "com.google.android.material:material:1.3.0"
+    implementation "com.google.android.material:material:1.4.0"
 
     // kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // androidx
-    implementation "androidx.core:core-ktx:1.3.2"
-    implementation "androidx.appcompat:appcompat:1.2.0"
+    implementation "androidx.core:core-ktx:1.6.0"
+    implementation "androidx.appcompat:appcompat:1.3.1"
     implementation "androidx.cardview:cardview:1.0.0"
-    implementation "androidx.recyclerview:recyclerview:1.2.0"
-    implementation "androidx.constraintlayout:constraintlayout:2.1.0-beta01"
-    implementation "androidx.fragment:fragment:1.3.0"
+    implementation "androidx.recyclerview:recyclerview:1.2.1"
+    implementation "androidx.constraintlayout:constraintlayout:2.1.0-rc01"
+    implementation "androidx.fragment:fragment-ktx:1.3.6"
 
     // test
     testImplementation "org.jetbrains.kotlin:kotlin-test"

--- a/devtools/android/build.gradle
+++ b/devtools/android/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     debugApi(project(':devtools:common')) { transitive = true }
     releaseApi("com.maximbircu:devtools-common:1.0.0") { transitive = true }
 
-    implementation "org.yaml:snakeyaml:1.27"
+    implementation "org.yaml:snakeyaml:1.29"
     implementation "com.google.android.material:material:1.4.0"
 
     // kotlin
@@ -71,5 +71,5 @@ dependencies {
     // test
     testImplementation "org.jetbrains.kotlin:kotlin-test"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
-    testImplementation "io.mockk:mockk:1.9.3"
+    testImplementation "io.mockk:mockk:1.12.0"
 }

--- a/devtools/android/build.gradle
+++ b/devtools/android/build.gradle
@@ -19,11 +19,11 @@ configureJacoco {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 30
+        targetSdkVersion 31
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'

--- a/devtools/android/build.gradle
+++ b/devtools/android/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.recyclerview:recyclerview:1.2.0"
     implementation "androidx.constraintlayout:constraintlayout:2.1.0-beta01"
+    implementation "androidx.fragment:fragment:1.3.0"
 
     // test
     testImplementation "org.jetbrains.kotlin:kotlin-test"

--- a/devtools/android/build.gradle
+++ b/devtools/android/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.3.1"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.recyclerview:recyclerview:1.2.1"
-    implementation "androidx.constraintlayout:constraintlayout:2.1.0-rc01"
+    implementation "androidx.constraintlayout:constraintlayout:2.1.0"
     implementation "androidx.fragment:fragment-ktx:1.3.6"
 
     // test

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/DevToolsConfigurationScreen.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/DevToolsConfigurationScreen.kt
@@ -11,19 +11,19 @@ class DevToolsConfigurationScreen private constructor() {
          * Use this method to display a dynamically generated configuration screen that will allow
          * the user to update the dev tools values.
          *
-         * @param viewGroup the root view to which the config screen view will be attached
+         * @param rootView the root view to which the config screen view will be attached
          * @param devTools the instance of [DevTools] class to be configurable by this screen
          * @param configScreenRouter (optional) an interface that will allow configuration screen
          *      implement navigation logic - provide this just in case you want to see discard
          *      dialog when trying to close the screen with unsaved changes
          */
         fun attachToView(
-            viewGroup: ViewGroup,
+            rootView: ViewGroup,
             devTools: DevTools,
             configScreenRouter: ConfigurationScreenRouter? = null
         ) {
-            val devToolsList = ConfigScreenLayout(viewGroup.context, devTools, configScreenRouter)
-            viewGroup.addView(devToolsList)
+            val devToolsList = ConfigScreenLayout(rootView.context, devTools, configScreenRouter)
+            rootView.addView(devToolsList)
         }
     }
 }

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/DevToolsConfigurationScreen.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/DevToolsConfigurationScreen.kt
@@ -3,15 +3,16 @@ package com.maximbircu.devtools.android
 import android.view.ViewGroup
 import com.maximbircu.devtools.android.presentation.configsreen.ConfigScreenLayout
 import com.maximbircu.devtools.common.DevTools
+import com.maximbircu.devtools.common.presentation.configscreen.ConfigurationScreenRouter
 
 class DevToolsConfigurationScreen private constructor() {
     companion object {
         fun attachToView(
             viewGroup: ViewGroup,
             devTools: DevTools,
-            closeScreen: (() -> Unit)? = null
+            configScreenRouter: ConfigurationScreenRouter? = null
         ) {
-            val devToolsList = ConfigScreenLayout(viewGroup.context, devTools, closeScreen)
+            val devToolsList = ConfigScreenLayout(viewGroup.context, devTools, configScreenRouter)
             viewGroup.addView(devToolsList)
         }
     }

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/DevToolsConfigurationScreen.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/DevToolsConfigurationScreen.kt
@@ -6,8 +6,12 @@ import com.maximbircu.devtools.common.DevTools
 
 class DevToolsConfigurationScreen private constructor() {
     companion object {
-        fun attachToView(viewGroup: ViewGroup, devTools: DevTools) {
-            val devToolsList = ConfigScreenLayout(viewGroup.context, devTools)
+        fun attachToView(
+            viewGroup: ViewGroup,
+            devTools: DevTools,
+            closeScreen: (() -> Unit)? = null
+        ) {
+            val devToolsList = ConfigScreenLayout(viewGroup.context, devTools, closeScreen)
             viewGroup.addView(devToolsList)
         }
     }

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/DevToolsConfigurationScreen.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/DevToolsConfigurationScreen.kt
@@ -7,6 +7,16 @@ import com.maximbircu.devtools.common.presentation.configscreen.ConfigurationScr
 
 class DevToolsConfigurationScreen private constructor() {
     companion object {
+        /**
+         * Use this method to display a dynamically generated configuration screen that will allow
+         * the user to update the dev tools values.
+         *
+         * @param viewGroup the root view to which the config screen view will be attached
+         * @param devTools the instance of [DevTools] class to be configurable by this screen
+         * @param configScreenRouter (optional) an interface that will allow configuration screen
+         *      implement navigation logic - provide this just in case you want to see discard
+         *      dialog when trying to close the screen with unsaved changes
+         */
         fun attachToView(
             viewGroup: ViewGroup,
             devTools: DevTools,

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/configsreen/ConfigScreenLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/configsreen/ConfigScreenLayout.kt
@@ -2,7 +2,6 @@ package com.maximbircu.devtools.android.presentation.configsreen
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.view.KeyEvent
 import android.widget.FrameLayout
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.maximbircu.devtools.android.R.string
@@ -12,21 +11,21 @@ import com.maximbircu.devtools.android.extensions.setOnClickListener
 import com.maximbircu.devtools.common.DevTools
 import com.maximbircu.devtools.common.presentation.configscreen.ConfigScreenPresenter
 import com.maximbircu.devtools.common.presentation.configscreen.ConfigScreenView
+import com.maximbircu.devtools.common.presentation.configscreen.ConfigurationScreenRouter
 
 @SuppressLint("ViewConstructor")
 internal class ConfigScreenLayout(
     context: Context,
     devTools: DevTools,
-    private val closeScreen: (() -> Unit)?
+    router: ConfigurationScreenRouter?
 ) : FrameLayout(context), ConfigScreenView {
     private val presenter: ConfigScreenPresenter
 
     init {
         val binding = LayoutConfigScreenBinding.inflate(context.inflater, this, true)
-        presenter = ConfigScreenPresenter.create(this, devTools, binding.devToolsList)
+        presenter = ConfigScreenPresenter.create(this, devTools, binding.devToolsList, router)
         presenter.onCreate()
         binding.applyButton.setOnClickListener(presenter::onApplyConfig)
-        closeScreen?.let { setBackButtonListener() }
     }
 
     override fun showConfirmationDialog(onConfirmed: () -> Unit) {
@@ -38,25 +37,8 @@ internal class ConfigScreenLayout(
             .show()
     }
 
-    override fun closeScreen() {
-        closeScreen?.invoke()
-    }
-
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         presenter.onDestroy()
-    }
-
-    private fun setBackButtonListener() {
-        isFocusableInTouchMode = true
-        requestFocus()
-        setOnKeyListener { _, keyCode, event ->
-            if (event.action == KeyEvent.ACTION_UP && keyCode == KeyEvent.KEYCODE_BACK) {
-                presenter.onAttemptToGoBack()
-                true
-            } else {
-                false
-            }
-        }
     }
 }

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/configsreen/ConfigScreenLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/configsreen/ConfigScreenLayout.kt
@@ -2,7 +2,10 @@ package com.maximbircu.devtools.android.presentation.configsreen
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.view.KeyEvent
 import android.widget.FrameLayout
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.maximbircu.devtools.android.R.string
 import com.maximbircu.devtools.android.databinding.LayoutConfigScreenBinding
 import com.maximbircu.devtools.android.extensions.inflater
 import com.maximbircu.devtools.android.extensions.setOnClickListener
@@ -13,15 +16,47 @@ import com.maximbircu.devtools.common.presentation.configscreen.ConfigScreenView
 @SuppressLint("ViewConstructor")
 internal class ConfigScreenLayout(
     context: Context,
-    devTools: DevTools
+    devTools: DevTools,
+    private val closeScreen: (() -> Unit)?
 ) : FrameLayout(context), ConfigScreenView {
     private val presenter: ConfigScreenPresenter
 
     init {
-        val binding =
-            LayoutConfigScreenBinding.inflate(context.inflater, this, true)
+        val binding = LayoutConfigScreenBinding.inflate(context.inflater, this, true)
         presenter = ConfigScreenPresenter.create(this, devTools, binding.devToolsList)
         presenter.onCreate()
         binding.applyButton.setOnClickListener(presenter::onApplyConfig)
+        closeScreen?.let { setBackButtonListener() }
+    }
+
+    override fun showConfirmationDialog(onConfirmed: () -> Unit) {
+        MaterialAlertDialogBuilder(context)
+            .setPositiveButton(android.R.string.ok) { _, _ -> onConfirmed() }
+            .setNegativeButton(android.R.string.cancel, null)
+            .setTitle(context.getString(string.config_screen_discard_changes))
+            .create()
+            .show()
+    }
+
+    override fun closeScreen() {
+        closeScreen?.invoke()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        presenter.onDestroy()
+    }
+
+    private fun setBackButtonListener() {
+        isFocusableInTouchMode = true
+        requestFocus()
+        setOnKeyListener { _, keyCode, event ->
+            if (event.action == KeyEvent.ACTION_UP && keyCode == KeyEvent.KEYCODE_BACK) {
+                presenter.onAttemptToGoBack()
+                true
+            } else {
+                false
+            }
+        }
     }
 }

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enumtool/selectors/dialog/EnumToolOptionsAdapter.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/enumtool/selectors/dialog/EnumToolOptionsAdapter.kt
@@ -1,5 +1,6 @@
 package com.maximbircu.devtools.android.presentation.tools.enumtool.selectors.dialog
 
+import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.RadioButton
@@ -7,6 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.maximbircu.devtools.android.R
 
+@SuppressLint("NotifyDataSetChanged")
 internal class EnumToolOptionsAdapter(
     private var onOptionSelected: (String) -> Unit = {},
     private val delegate: EnumToolOptionsAdapterDelegate = EnumToolOptionsAdapterDelegate.create()

--- a/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/group/GroupToolLayout.kt
+++ b/devtools/android/src/main/kotlin/com/maximbircu/devtools/android/presentation/tools/group/GroupToolLayout.kt
@@ -1,5 +1,6 @@
 package com.maximbircu.devtools.android.presentation.tools.group
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.widget.PopupMenu
 import com.maximbircu.devtools.android.R
@@ -34,6 +35,7 @@ class GroupToolLayout(context: Context) : DevToolLayout<GroupTool>(context), Gro
         popup.show()
     }
 
+    @SuppressLint("NotifyDataSetChanged")
     override fun refreshToolData() {
         devToolsViewsContainer.adapter?.notifyDataSetChanged()
     }

--- a/devtools/android/src/main/res/layout/layout_dev_tool.xml
+++ b/devtools/android/src/main/res/layout/layout_dev_tool.xml
@@ -4,6 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginBottom="16dp"
+    app:cardCornerRadius="10dp"
+    app:elevation="30dp"
     android:id="@+id/devToolCard"
     android:theme="@style/Theme.DevTools"
     >

--- a/devtools/android/src/main/res/values/strings.xml
+++ b/devtools/android/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <!-- Config Screen -->
     <string name="config_screen_apply_button">Apply</string>
+    <string name="config_screen_discard_changes">There are some unsaved changes, discard?</string>
 
     <!-- Toggle Tool -->
     <string name="toggle_tool_is_enabled">Is enabled</string>

--- a/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/presentation/tool/DevToolContextMenuClickListenerTest.kt
+++ b/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/presentation/tool/DevToolContextMenuClickListenerTest.kt
@@ -17,7 +17,7 @@ class DevToolContextMenuClickListenerTest : BaseTest() {
     private val listener = DevToolContextMenuClickListener(presenter)
 
     @Test
-    fun `notifies about "help" click and consumes the action`() {
+    fun `notifies about help click and consumes the action`() {
         val isActionConsumed = listener.onMenuItemClick(createMenuItem(R.id.help))
 
         verify { presenter.onHelp() }
@@ -25,7 +25,7 @@ class DevToolContextMenuClickListenerTest : BaseTest() {
     }
 
     @Test
-    fun `notifies about "select default value" click and consumes the action`() {
+    fun `notifies about select default value click and consumes the action`() {
         val isActionConsumed = listener.onMenuItemClick(createMenuItem(R.id.select_default_value))
 
         verify { presenter.onSelectDefaultValue() }
@@ -33,7 +33,7 @@ class DevToolContextMenuClickListenerTest : BaseTest() {
     }
 
     @Test
-    fun `notifies about "reset changes" click and consumes the action`() {
+    fun `notifies about reset changes click and consumes the action`() {
         val isActionConsumed = listener.onMenuItemClick(createMenuItem(R.id.reset_changes))
 
         verify { presenter.onResetChanges() }

--- a/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/presentation/tool/help/StartupArgumentFlagProviderTest.kt
+++ b/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/presentation/tool/help/StartupArgumentFlagProviderTest.kt
@@ -7,42 +7,42 @@ import kotlin.test.assertFailsWith
 
 class StartupArgumentFlagProviderTest : BaseTest() {
     @Test
-    fun `returns "--es" startup argument flag for a string value`() {
+    fun `returns --es startup argument flag for a string value`() {
         val flag = StartupArgumentFlagProvider.getFor("String config value")
 
         assertEquals("--es", flag)
     }
 
     @Test
-    fun `returns "--ez" startup argument flag for a boolean value`() {
+    fun `returns --ez startup argument flag for a boolean value`() {
         val flag = StartupArgumentFlagProvider.getFor(true)
 
         assertEquals("--ez", flag)
     }
 
     @Test
-    fun `returns "--ei" startup argument flag for a int value`() {
+    fun `returns --ei startup argument flag for a int value`() {
         val flag = StartupArgumentFlagProvider.getFor(1)
 
         assertEquals("--ei", flag)
     }
 
     @Test
-    fun `returns "--el" startup argument flag for a long value`() {
+    fun `returns --el startup argument flag for a long value`() {
         val flag = StartupArgumentFlagProvider.getFor(1L)
 
         assertEquals("--el", flag)
     }
 
     @Test
-    fun `returns "--ef" startup argument flag for a float value`() {
+    fun `returns --ef startup argument flag for a float value`() {
         val flag = StartupArgumentFlagProvider.getFor(1f)
 
         assertEquals("--ef", flag)
     }
 
     @Test
-    fun `returns "--ef" startup argument flag for a double value`() {
+    fun `returns --ef startup argument flag for a double value`() {
         val flag = StartupArgumentFlagProvider.getFor(1.0)
 
         assertEquals("--ef", flag)

--- a/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/presentation/tools/group/GroupToolContextMenuClickListenerTest.kt
+++ b/devtools/android/src/test/kotlin/com/maximbircu/devtools/android/presentation/tools/group/GroupToolContextMenuClickListenerTest.kt
@@ -17,7 +17,7 @@ class GroupToolContextMenuClickListenerTest : BaseTest() {
     private val listener = GroupToolContextMenuClickListener(presenter)
 
     @Test
-    fun `notifies about "enable all" click and consumes the action`() {
+    fun `notifies about enable all click and consumes the action`() {
         val isActionConsumed = listener.onMenuItemClick(createMenuItem(R.id.enable_all))
 
         verify { presenter.onEnableAll() }
@@ -25,7 +25,7 @@ class GroupToolContextMenuClickListenerTest : BaseTest() {
     }
 
     @Test
-    fun `notifies about "disable all" click and consumes the action`() {
+    fun `notifies about disable all click and consumes the action`() {
         val isActionConsumed = listener.onMenuItemClick(createMenuItem(R.id.disable_all))
 
         verify { presenter.onDisableAll() }
@@ -33,7 +33,7 @@ class GroupToolContextMenuClickListenerTest : BaseTest() {
     }
 
     @Test
-    fun `notifies about "set all to default" click and consumes the action`() {
+    fun `notifies about set all to default click and consumes the action`() {
         val isActionConsumed = listener.onMenuItemClick(createMenuItem(R.id.set_all_to_default))
 
         verify { presenter.onSetAllToDefault() }
@@ -41,7 +41,7 @@ class GroupToolContextMenuClickListenerTest : BaseTest() {
     }
 
     @Test
-    fun `notifies about "reset all changes" click and consumes the action`() {
+    fun `notifies about reset all changes click and consumes the action`() {
         val isActionConsumed = listener.onMenuItemClick(createMenuItem(R.id.reset_all_changes))
 
         verify { presenter.onResetAllChanges() }

--- a/devtools/common/build.gradle
+++ b/devtools/common/build.gradle
@@ -54,7 +54,8 @@ kotlin {
         commonMain {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib-common"
-                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-common:0.20.0"
+//                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-common:1.2.2"
+                implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2"
             }
         }
 
@@ -62,14 +63,14 @@ kotlin {
             dependsOn commonMain
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib"
-                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.20.0"
+//                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:1.2.2"
             }
         }
 
         iosMain {
             dependsOn commonMain
             dependencies {
-                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:0.20.0"
+//                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:1.2.2"
             }
         }
 

--- a/devtools/common/build.gradle
+++ b/devtools/common/build.gradle
@@ -28,6 +28,8 @@ android {
     }
 
     libraryVariants.all { it.generateBuildConfig.enabled = false }
+
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
 }
 
 kotlin {
@@ -75,8 +77,7 @@ kotlin {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-test-common"
                 implementation "org.jetbrains.kotlin:kotlin-test-annotations-common"
-                implementation "io.mockk:mockk:1.9.3"
-                implementation "io.mockk:mockk-common:1.9.3"
+                implementation "io.mockk:mockk-common:1.12.0"
             }
         }
 
@@ -84,6 +85,8 @@ kotlin {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-test"
                 implementation "org.jetbrains.kotlin:kotlin-test-junit"
+
+                implementation "io.mockk:mockk:1.12.0"
             }
         }
     }

--- a/devtools/common/build.gradle
+++ b/devtools/common/build.gradle
@@ -85,7 +85,6 @@ kotlin {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-test"
                 implementation "org.jetbrains.kotlin:kotlin-test-junit"
-
                 implementation "io.mockk:mockk:1.12.0"
             }
         }

--- a/devtools/common/build.gradle
+++ b/devtools/common/build.gradle
@@ -13,7 +13,7 @@ configurePublishing {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     buildTypes {
         release {

--- a/devtools/common/build.gradle
+++ b/devtools/common/build.gradle
@@ -54,7 +54,6 @@ kotlin {
         commonMain {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib-common"
-//                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-common:1.2.2"
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2"
             }
         }
@@ -63,14 +62,12 @@ kotlin {
             dependsOn commonMain
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib"
-//                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:1.2.2"
             }
         }
 
         iosMain {
             dependsOn commonMain
             dependencies {
-//                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:1.2.2"
             }
         }
 
@@ -104,7 +101,7 @@ kotlin {
     afterEvaluate {
         tasks.forEach { task ->
             def taskName = task.name
-            if(taskName.toLowerCase().contains("ios") && taskName.toLowerCase().contains("test")) {
+            if (taskName.toLowerCase().contains("ios") && taskName.toLowerCase().contains("test")) {
                 task.setEnabled(false)
             }
             if (taskName.contains("assemble")) {

--- a/devtools/common/src/androidMain/AndroidManifest.xml
+++ b/devtools/common/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.maximbircu.devtools.common" />

--- a/devtools/common/src/androidTest/kotlin/com/maximbircu/devtools/common/SharedPreferencesExtensionsTest.kt
+++ b/devtools/common/src/androidTest/kotlin/com/maximbircu/devtools/common/SharedPreferencesExtensionsTest.kt
@@ -137,7 +137,7 @@ class SharedPreferencesExtensionsTest : BaseTest() {
     @Test
     fun `restores double value properly if the key exists and it was stored`() {
         every { sharedPrefs.contains("radio-tool") } returns true
-        every { sharedPrefs.all["radio-tool"] } returns doubleToRawLongBits(25.3)
+        every { sharedPrefs.all } returns mapOf("radio-tool" to doubleToRawLongBits(25.3))
 
         val actualValue = sharedPrefs.getDouble("radio-tool", 30.0)
 

--- a/devtools/common/src/androidTest/kotlin/com/maximbircu/devtools/common/stores/PreferencesToolStoreImplTest.kt
+++ b/devtools/common/src/androidTest/kotlin/com/maximbircu/devtools/common/stores/PreferencesToolStoreImplTest.kt
@@ -2,6 +2,7 @@ package com.maximbircu.devtools.common.stores
 
 import android.content.SharedPreferences
 import com.maximbircu.devtools.common.SharedPreferencesProvider
+import com.maximbircu.devtools.common.core.createTool
 import com.maximbircu.devtools.common.mvp.BaseTest
 import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
 import com.maximbircu.devtools.common.utils.mockk
@@ -54,6 +55,11 @@ class PreferencesToolStoreImplTest : BaseTest() {
         every { sharedPrefs.getBoolean("toggle-tool", false) } returns true
 
         assertTrue(preferencesStore.value)
+    }
+
+    @Test
+    fun `creates a proper instance of prefs store implementation`() {
+        assertTrue(PreferencesToolStore.create<Int>(createTool { }) is PreferencesToolStoreImpl)
     }
 
     private fun createPreferencesStore(

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
@@ -22,6 +22,8 @@ interface DevTools : DevToolsStorage {
      */
     fun persistToolsState()
 
+    fun restorePersistedState()
+
     /**
      * Updates all dev tools with values taken from [params].
      *
@@ -63,7 +65,7 @@ private class DevToolsImpl(
     override var onConfigUpdated: (isCriticalUpdate: Boolean) -> Unit
 ) : DevTools, DevToolsStorage by toolsStorage {
     init {
-        tools.forEachRecursively { _, tool -> tool.restorePersistedState() }
+        restorePersistedState()
     }
 
     override fun updateFromParams(params: Map<String, Any>) {
@@ -84,6 +86,10 @@ private class DevToolsImpl(
         if (atLeastOneToolWasUpdated) {
             onConfigUpdated(isCriticalUpdate)
         }
+    }
+
+    override fun restorePersistedState() {
+        tools.forEachRecursively { _, tool -> tool.restorePersistedState() }
     }
 
     private fun persistToolsStateRecursively(): Pair<Boolean, Boolean> {

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/DevTools.kt
@@ -24,6 +24,8 @@ interface DevTools : DevToolsStorage {
 
     fun restorePersistedState()
 
+    val thereExistUnsavedChanges: Boolean
+
     /**
      * Updates all dev tools with values taken from [params].
      *
@@ -67,6 +69,18 @@ private class DevToolsImpl(
     init {
         restorePersistedState()
     }
+
+    override val thereExistUnsavedChanges: Boolean
+        get() {
+            var hasUnsavedChanges = false
+            tools.forEachRecursively { _, devTool ->
+                if (devTool.hasUnsavedChanges) {
+                    hasUnsavedChanges = true
+                    return@forEachRecursively
+                }
+            }
+            return hasUnsavedChanges
+        }
 
     override fun updateFromParams(params: Map<String, Any>) {
         if (params.isEmpty()) return

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenter.kt
@@ -53,7 +53,12 @@ private class ConfigScreenPresenterImpl(
 
     private fun setUpRouter() = router?.run {
         onBack = {
-            if (true) true.also { view.showConfirmationDialog(::closeScreen) } else false
+            if (devTools.thereExistUnsavedChanges) {
+                view.showConfirmationDialog(::closeScreen)
+                true
+            } else {
+                false
+            }
         }
     }
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenter.kt
@@ -13,6 +13,11 @@ interface ConfigScreenPresenter : Presenter {
      */
     fun onCreate()
 
+    /**
+     * Should be invoked when the configuration screen is closed and destroyed.
+     *
+     * Rests the in memory dev tools changes.
+     */
     fun onDestroy()
 
     /**

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenter.kt
@@ -13,6 +13,10 @@ interface ConfigScreenPresenter : Presenter {
      */
     fun onCreate()
 
+    fun onAttemptToGoBack()
+
+    fun onDestroy()
+
     /**
      * Should be invoked when the user wants to apply the dev tools config changes he made.
      *
@@ -37,6 +41,14 @@ private class ConfigScreenPresenterImpl(
     private val devToolsList: DevToolsListView
 ) : BasePresenter<ConfigScreenView>(view), ConfigScreenPresenter {
     override fun onCreate() = devToolsList.showDevTools(devTools.tools.values.toList())
+
+    override fun onAttemptToGoBack() {
+        view.showConfirmationDialog(view::closeScreen)
+    }
+
+    override fun onDestroy() {
+        // TODO Reset config here
+    }
 
     override fun onApplyConfig() = devTools.persistToolsState()
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenter.kt
@@ -32,7 +32,7 @@ interface ConfigScreenPresenter : Presenter {
             view: ConfigScreenView,
             devTools: DevTools,
             devToolsList: DevToolsListView,
-            router: ConfigurationScreenRouter? = null
+            router: ConfigurationScreenRouter?
         ): ConfigScreenPresenter {
             return ConfigScreenPresenterImpl(view, devTools, devToolsList, router)
         }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenter.kt
@@ -13,8 +13,6 @@ interface ConfigScreenPresenter : Presenter {
      */
     fun onCreate()
 
-    fun onAttemptToGoBack()
-
     fun onDestroy()
 
     /**
@@ -28,9 +26,10 @@ interface ConfigScreenPresenter : Presenter {
         fun create(
             view: ConfigScreenView,
             devTools: DevTools,
-            devToolsList: DevToolsListView
+            devToolsList: DevToolsListView,
+            router: ConfigurationScreenRouter? = null
         ): ConfigScreenPresenter {
-            return ConfigScreenPresenterImpl(view, devTools, devToolsList)
+            return ConfigScreenPresenterImpl(view, devTools, devToolsList, router)
         }
     }
 }
@@ -38,17 +37,23 @@ interface ConfigScreenPresenter : Presenter {
 private class ConfigScreenPresenterImpl(
     view: ConfigScreenView,
     private val devTools: DevTools,
-    private val devToolsList: DevToolsListView
+    private val devToolsList: DevToolsListView,
+    private val router: ConfigurationScreenRouter?
 ) : BasePresenter<ConfigScreenView>(view), ConfigScreenPresenter {
-    override fun onCreate() = devToolsList.showDevTools(devTools.tools.values.toList())
-
-    override fun onAttemptToGoBack() {
-        view.showConfirmationDialog(view::closeScreen)
+    override fun onCreate() {
+        devToolsList.showDevTools(devTools.tools.values.toList())
+        setUpRouter()
     }
 
     override fun onDestroy() {
-        // TODO Reset config here
+        devTools.restorePersistedState()
     }
 
     override fun onApplyConfig() = devTools.persistToolsState()
+
+    private fun setUpRouter() = router?.run {
+        onBack = {
+            if (true) true.also { view.showConfirmationDialog(::closeScreen) } else false
+        }
+    }
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenView.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenView.kt
@@ -6,4 +6,8 @@ import com.maximbircu.devtools.common.core.mvp.BaseView
  * The configuration interface which displays all dev tools parsed from the configuration and allows
  * the user to manipulate their state and configuration values.
  */
-interface ConfigScreenView : BaseView
+interface ConfigScreenView : BaseView {
+    fun closeScreen()
+
+    fun showConfirmationDialog(onConfirmed: () -> Unit)
+}

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenView.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenView.kt
@@ -7,7 +7,5 @@ import com.maximbircu.devtools.common.core.mvp.BaseView
  * the user to manipulate their state and configuration values.
  */
 interface ConfigScreenView : BaseView {
-    fun closeScreen()
-
     fun showConfirmationDialog(onConfirmed: () -> Unit)
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigurationScreenRouter.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigurationScreenRouter.kt
@@ -1,0 +1,7 @@
+package com.maximbircu.devtools.common.presentation.configscreen
+
+interface ConfigurationScreenRouter {
+    var onBack: (() -> Boolean)?
+
+    fun closeScreen()
+}

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolStore.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolStore.kt
@@ -14,6 +14,10 @@ class GroupToolStore : PreferencesToolStore<Unit> {
      * its children themselves.
      */
     override var isEnabled: Boolean = true
+        @Suppress("UNUSED_PARAMETER")
+        set(value) = throw IllegalStateException("Can not enable/disable a group tool")
 
     override var value: Unit = Unit
+        @Suppress("UNUSED_PARAMETER")
+        set(value) = throw IllegalStateException("Can not modify a group tool value")
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaDevToolFactoryProducer.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaDevToolFactoryProducer.kt
@@ -15,10 +15,6 @@ internal class JsonSchemaDevToolFactoryProducer(private val jsonObject: JsonObje
     private val properties: Map<String, JsonSchemaToolFactory<*>>
         get() = jsonObject["properties"]!!.jsonObject.toFactoriesMap()
 
-    init {
-        jsonObject["type"]?.jsonPrimitive?.content
-    }
-
     fun getDevToolFactory(): JsonSchemaToolFactory<*> {
         return if (jsonObject["enum"] != null) {
             JsonSchemaEnumToolFactory(jsonObject)

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaDevToolFactoryProducer.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaDevToolFactoryProducer.kt
@@ -7,11 +7,17 @@ import com.maximbircu.devtools.common.readers.jsonschema.factories.JsonSchemaTex
 import com.maximbircu.devtools.common.readers.jsonschema.factories.JsonSchemaTextToolIntegerFactory
 import com.maximbircu.devtools.common.readers.jsonschema.factories.JsonSchemaToggleToolFactory
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 internal class JsonSchemaDevToolFactoryProducer(private val jsonObject: JsonObject) {
-    private val type = jsonObject.getValue("type").primitive.content
+    private val type = jsonObject["type"]!!.jsonPrimitive.content
     private val properties: Map<String, JsonSchemaToolFactory<*>>
-        get() = jsonObject.getValue("properties").jsonObject.toFactoriesMap()
+        get() = jsonObject["properties"]!!.jsonObject.toFactoriesMap()
+
+    init {
+        jsonObject["type"]?.jsonPrimitive?.content
+    }
 
     fun getDevToolFactory(): JsonSchemaToolFactory<*> {
         return if (jsonObject["enum"] != null) {

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaReader.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaReader.kt
@@ -4,14 +4,11 @@ import com.maximbircu.devtools.common.core.DevTool
 import com.maximbircu.devtools.common.core.reader.DevToolsReader
 import com.maximbircu.devtools.common.presentation.tools.group.GroupTool
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration.Companion.Stable
 import kotlinx.serialization.json.JsonObject
 
 internal class JsonSchemaReader(private val jsonSchemaString: String) : DevToolsReader {
-    private val json = Json(Stable.copy(ignoreUnknownKeys = true))
-
     override fun getDevTools(): Map<String, DevTool<*>> {
-        val jsonObject = json.parse(JsonObject.serializer(), jsonSchemaString)
+        val jsonObject = Json.decodeFromString(JsonObject.serializer(), jsonSchemaString)
         val factory = JsonSchemaDevToolFactoryProducer(jsonObject).getDevToolFactory()
         return (factory.create() as GroupTool).tools
     }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaToolFactory.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaToolFactory.kt
@@ -4,19 +4,19 @@ import com.maximbircu.devtools.common.core.DevTool
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.boolean
-import kotlinx.serialization.json.content
+import kotlinx.serialization.json.jsonPrimitive
 
 internal abstract class JsonSchemaToolFactory<T : DevTool<*>>(
     protected val jsonObject: JsonObject
 ) {
-    protected val default: JsonPrimitive? = jsonObject["default"]?.primitive
+    protected val default: JsonPrimitive? = jsonObject["default"]?.jsonPrimitive
 
     fun create(): T = createDevTool().apply {
-        title = jsonObject["title"]?.content
-        description = jsonObject["description"]?.content ?: ""
-        canBeDisabled = jsonObject["canBeDisabled"]?.boolean ?: true
-        defaultEnabledValue = jsonObject["defaultEnabledValue"]?.boolean ?: false
-        isCritical = jsonObject["isCritical"]?.boolean ?: true
+        title = jsonObject["title"]?.jsonPrimitive?.content
+        description = jsonObject["description"]?.jsonPrimitive?.content ?: ""
+        canBeDisabled = jsonObject["canBeDisabled"]?.jsonPrimitive?.boolean ?: true
+        defaultEnabledValue = jsonObject["defaultEnabledValue"]?.jsonPrimitive?.boolean ?: false
+        isCritical = jsonObject["isCritical"]?.jsonPrimitive?.boolean ?: true
     }
 
     protected abstract fun createDevTool(): T

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaEnumToolFactory.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaEnumToolFactory.kt
@@ -5,18 +5,20 @@ import com.maximbircu.devtools.common.presentation.tools.enum.EnumTool
 import com.maximbircu.devtools.common.readers.jsonschema.JsonSchemaToolFactory
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.boolean
-import kotlinx.serialization.json.content
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
 
 internal class JsonSchemaEnumToolFactory(
     jsonObject: JsonObject
 ) : JsonSchemaToolFactory<EnumTool>(jsonObject) {
     override fun createDevTool(): EnumTool = EnumTool(
         defaultValueKey = default?.content,
-        allowCustom = jsonObject["allowCustom"]?.boolean ?: false,
+        allowCustom = jsonObject["allowCustom"]?.jsonPrimitive?.boolean ?: false,
         optionsProvider = object : EnumOptionsProvider {
             override fun getOptions(): Map<String, String> {
                 val enumOptions = jsonObject.getValue("enum").jsonArray
-                return enumOptions.map { it.content to it.content }.toMap()
+                return enumOptions.map { it.jsonPrimitive.content to it.jsonPrimitive.content }
+                    .toMap()
             }
         }
     )

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolDoubleFactory.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolDoubleFactory.kt
@@ -3,11 +3,13 @@ package com.maximbircu.devtools.common.readers.jsonschema.factories
 import com.maximbircu.devtools.common.presentation.tools.text.TextTool
 import com.maximbircu.devtools.common.readers.jsonschema.JsonSchemaToolFactory
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.jsonPrimitive
 
 internal class JsonSchemaTextToolDoubleFactory(
     jsonObject: JsonObject
 ) : JsonSchemaToolFactory<TextTool>(jsonObject) {
-    private val hint = jsonObject["hint"]?.primitive
+    private val hint = jsonObject["hint"]?.jsonPrimitive
 
     override fun createDevTool() = TextTool(default?.double ?: 0.0, hint?.content)
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolFactory.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolFactory.kt
@@ -3,11 +3,12 @@ package com.maximbircu.devtools.common.readers.jsonschema.factories
 import com.maximbircu.devtools.common.presentation.tools.text.TextTool
 import com.maximbircu.devtools.common.readers.jsonschema.JsonSchemaToolFactory
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 internal class JsonSchemaTextToolFactory(
     jsonObject: JsonObject
 ) : JsonSchemaToolFactory<TextTool>(jsonObject) {
-    private val hint = jsonObject["hint"]?.primitive
+    private val hint = jsonObject["hint"]?.jsonPrimitive
 
     override fun createDevTool() = TextTool(default?.content ?: "", hint?.content)
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolIntegerFactory.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolIntegerFactory.kt
@@ -3,11 +3,13 @@ package com.maximbircu.devtools.common.readers.jsonschema.factories
 import com.maximbircu.devtools.common.presentation.tools.text.TextTool
 import com.maximbircu.devtools.common.readers.jsonschema.JsonSchemaToolFactory
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonPrimitive
 
 internal class JsonSchemaTextToolIntegerFactory(
     jsonObject: JsonObject
 ) : JsonSchemaToolFactory<TextTool>(jsonObject) {
-    private val hint = jsonObject["hint"]?.primitive
+    private val hint = jsonObject["hint"]?.jsonPrimitive
 
     override fun createDevTool() = TextTool(default?.int ?: 0, hint?.content)
 }

--- a/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaToggleToolFactory.kt
+++ b/devtools/common/src/commonMain/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaToggleToolFactory.kt
@@ -3,6 +3,7 @@ package com.maximbircu.devtools.common.readers.jsonschema.factories
 import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
 import com.maximbircu.devtools.common.readers.jsonschema.JsonSchemaToolFactory
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
 
 internal class JsonSchemaToggleToolFactory(
     jsonObject: JsonObject

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
@@ -100,9 +100,9 @@ class DevToolsImplTest : BaseTest() {
                     },
                     "second-tool" to createTool()
                 )
-            ),
-            onConfigUpdate = onConfigUpdate
+            )
         )
+        devTools.onConfigUpdated = onConfigUpdate
 
         devTools.persistToolsState()
 

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsImplTest.kt
@@ -16,6 +16,7 @@ import io.mockk.clearAllMocks
 import io.mockk.spyk
 import io.mockk.verify
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class DevToolsImplTest : BaseTest() {
     @Test
@@ -170,5 +171,22 @@ class DevToolsImplTest : BaseTest() {
         tools.values.forEach { tool -> verify { tool wasNot Called } }
         childTools.values.forEach { tool -> verify { tool wasNot Called } }
         verify(exactly = 0) { devTools.persistToolsState() }
+    }
+
+    @Test
+    fun `checks `() {
+        val tools = mapOf(
+            "first-tool" to createTool { ::hasUnsavedChanges returns true },
+            "second-tool" to createTool<GroupTool> {
+                ::tools returns mapOf(
+                    "first-child-tool" to createTool<ToggleTool>(),
+                    "second-child-tool" to createTool<TextTool> { ::hasUnsavedChanges returns true }
+                )
+            }
+        )
+
+        val devTools = DevTools.create("TEST", DevToolsSources.memory(tools))
+
+        assertTrue(devTools.thereExistUnsavedChanges)
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsParserImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsParserImplTest.kt
@@ -20,7 +20,8 @@ class DevToolsParserImplTest : BaseTest() {
             "first-source-first-tool" to createTool(),
             "first-source-second-tool" to createTool()
         )
-        val childTools = mapOf<String, DevTool<*>>("child-tool" to createTool())
+        val childChildTools = mapOf<String, DevTool<*>>("child-child-tool" to createTool())
+        val childTools = mapOf<String, DevTool<*>>("child-tool" to spyk(GroupTool(childChildTools)))
         val source2Tools = mapOf<String, DevTool<*>>(
             "second-source-first-tool" to createTool(),
             "second-source-second-tool" to createTool(),

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsStorageImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/DevToolsStorageImplTest.kt
@@ -7,7 +7,9 @@ import com.maximbircu.devtools.common.presentation.tools.group.GroupTool
 import com.maximbircu.devtools.common.presentation.tools.text.TextTool
 import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
 import com.maximbircu.devtools.common.utils.returns
-import kotlinx.serialization.json.json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -69,11 +71,11 @@ class DevToolsStorageImplTest : BaseTest() {
                 )
             )
         )
-        val expectedConfigJsonString = json {
-            "first-tool" to true
-            "second-tool" to json {
-                "first-child-tool" to "First value"
-                "second-child-tool" to "Second value"
+        val expectedConfigJsonString = buildJsonObject {
+            put("first-tool", true)
+            putJsonObject("second-tool") {
+                put("first-child-tool", "First value")
+                put("second-child-tool", "Second value")
             }
         }.toString()
         val storage: DevToolsStorage = DevToolsStorageImpl(tools)
@@ -119,11 +121,11 @@ class DevToolsStorageImplTest : BaseTest() {
                 )
             )
         )
-        val expectedConfigJsonString = json {
-            "first-tool" to true
-            "third-tool" to json {
-                "second-child-tool" to "Second value"
-                "third-child-tool" to 3.4
+        val expectedConfigJsonString = buildJsonObject {
+            put("first-tool", true)
+            putJsonObject("third-tool") {
+                put("second-child-tool", "Second value")
+                put("third-child-tool", 3.4)
             }
         }.toString()
         val storage: DevToolsStorage = DevToolsStorageImpl(tools)

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/extensions/DevToolExtensionsKtTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/extensions/DevToolExtensionsKtTest.kt
@@ -8,7 +8,9 @@ import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
 import com.maximbircu.devtools.common.utils.mockk
 import com.maximbircu.devtools.common.utils.returns
 import io.mockk.verify
-import kotlinx.serialization.json.json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -38,11 +40,11 @@ class DevToolExtensionsKtTest {
                 )
             )
         )
-        val expectedConfigJsonObject = json {
-            "first-tool" to true
-            "second-tool" to json {
-                "first-child-tool" to "First value"
-                "second-child-tool" to "Second value"
+        val expectedConfigJsonObject = buildJsonObject {
+            put("first-tool", true)
+            putJsonObject("second-tool") {
+                put("first-child-tool", "First value")
+                put("second-child-tool", "Second value")
             }
         }
 
@@ -87,11 +89,11 @@ class DevToolExtensionsKtTest {
                 )
             )
         )
-        val expectedConfigJsonObject = json {
-            "first-tool" to true
-            "third-tool" to json {
-                "second-child-tool" to "Second value"
-                "third-child-tool" to 3.4
+        val expectedConfigJsonObject = buildJsonObject {
+            put("first-tool", true)
+            putJsonObject("third-tool") {
+                put("second-child-tool", "Second value")
+                put("third-child-tool", 3.4)
             }
         }
 

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenterImplTest.kt
@@ -7,15 +7,18 @@ import com.maximbircu.devtools.common.mvp.BasePresenterTest
 import com.maximbircu.devtools.common.presentation.list.DevToolsListView
 import com.maximbircu.devtools.common.utils.mockk
 import io.mockk.every
+import io.mockk.slot
 import io.mockk.verify
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class ConfigScreenPresenterImplTest :
     BasePresenterTest<ConfigScreenView, ConfigScreenPresenter>(mockk()) {
     private val devTools: DevTools = mockk()
     private val devToolsList: DevToolsListView = mockk()
+    private val router: ConfigurationScreenRouter = mockk(relaxed = true)
 
-    override fun createPresenter() = ConfigScreenPresenter.create(view, devTools, devToolsList)
+    override fun createPresenter(): ConfigScreenPresenter = createPresenter(router)
 
     @Test
     fun `shows dev tools on create`() {
@@ -31,9 +34,71 @@ class ConfigScreenPresenterImplTest :
     }
 
     @Test
+    fun `restores persisted state on destroy`() {
+        presenter.onDestroy()
+
+        verify { devTools.restorePersistedState() }
+    }
+
+    @Test
+    fun `shows discard dialog if there are unsaved changes`() {
+        val router = RouterStub()
+        presenter = createPresenter(router)
+        val tools = mapOf<String, DevTool<Boolean>>("first-tool" to createTool())
+        every { devTools.tools } returns tools
+        every { devTools.thereExistUnsavedChanges } returns true
+        presenter.onCreate()
+
+        router.onBack?.invoke()
+
+        verify { view.showConfirmationDialog(any()) }
+    }
+
+    @Test
+    fun `returns false on back if there are no unsaved changes`() {
+        val router = RouterStub()
+        presenter = createPresenter(router)
+        val tools = mapOf<String, DevTool<Boolean>>("first-tool" to createTool())
+        every { devTools.tools } returns tools
+        every { devTools.thereExistUnsavedChanges } returns false
+        presenter.onCreate()
+
+        assertTrue(router.onBack?.invoke() == false)
+    }
+
+    @Test
+    fun `closes screen on confirmation`() {
+        val router = RouterStub()
+        presenter = createPresenter(router)
+        val tools = mapOf<String, DevTool<Boolean>>("first-tool" to createTool())
+        every { devTools.tools } returns tools
+        every { devTools.thereExistUnsavedChanges } returns true
+        val slot = slot<() -> Unit>()
+        every { view.showConfirmationDialog(capture(slot)) } answers { slot.captured.invoke() }
+        presenter.onCreate()
+
+        router.onBack?.invoke()
+
+        verify { router.closeScreenListener() }
+    }
+
+    @Test
     fun `persists tool state on apply config`() {
         presenter.onApplyConfig()
 
         devTools.persistToolsState()
+    }
+
+    private fun createPresenter(router: ConfigurationScreenRouter): ConfigScreenPresenter {
+        return ConfigScreenPresenter.create(view, devTools, devToolsList, router)
+    }
+}
+
+private class RouterStub : ConfigurationScreenRouter {
+    override var onBack: (() -> Boolean)? = null
+    val closeScreenListener: () -> Unit = mockk(relaxed = true)
+
+    override fun closeScreen() {
+        closeScreenListener()
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/configscreen/ConfigScreenPresenterImplTest.kt
@@ -6,6 +6,7 @@ import com.maximbircu.devtools.common.core.createTool
 import com.maximbircu.devtools.common.mvp.BasePresenterTest
 import com.maximbircu.devtools.common.presentation.list.DevToolsListView
 import com.maximbircu.devtools.common.utils.mockk
+import io.mockk.Called
 import io.mockk.every
 import io.mockk.slot
 import io.mockk.verify
@@ -14,8 +15,8 @@ import kotlin.test.assertTrue
 
 class ConfigScreenPresenterImplTest :
     BasePresenterTest<ConfigScreenView, ConfigScreenPresenter>(mockk()) {
-    private val devTools: DevTools = mockk()
-    private val devToolsList: DevToolsListView = mockk()
+    private val devTools: DevTools = mockk(relaxed = true)
+    private val devToolsList: DevToolsListView = mockk(relaxed = true)
     private val router: ConfigurationScreenRouter = mockk(relaxed = true)
 
     override fun createPresenter(): ConfigScreenPresenter = createPresenter(router)
@@ -89,7 +90,15 @@ class ConfigScreenPresenterImplTest :
         devTools.persistToolsState()
     }
 
-    private fun createPresenter(router: ConfigurationScreenRouter): ConfigScreenPresenter {
+    @Test
+    fun `doesn't use the router if it was not pass`() {
+        val presenter = createPresenter(null)
+        presenter.onCreate()
+
+        verify { view wasNot Called }
+    }
+
+    private fun createPresenter(router: ConfigurationScreenRouter?): ConfigScreenPresenter {
         return ConfigScreenPresenter.create(view, devTools, devToolsList, router)
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolOptionSelectorPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolOptionSelectorPresenterImplTest.kt
@@ -90,7 +90,13 @@ class EnumToolOptionSelectorPresenterImplTest :
 
     @Test
     fun `hides custom value input view if selected option is not custom`() {
-        presenter.onToolBind(createTool { ::value returns "some custom value" })
+        val fakeOptions = mapOf("first-option" to "first-value", "second-option" to "second-value")
+        val tool: EnumTool = createTool {
+            ::allowCustom returns false
+            ::options returns fakeOptions
+            ::value returns "first-value"
+        }
+        presenter.onToolBind(tool)
 
         presenter.onOptionSelected("second-option")
 

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/enum/EnumToolTest.kt
@@ -4,6 +4,7 @@ import com.maximbircu.devtools.common.mvp.BaseTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class EnumToolTest : BaseTest() {
     @Test
@@ -15,7 +16,7 @@ class EnumToolTest : BaseTest() {
 
     @Test
     fun `throws exception if the default value key was not provided`() {
-        val tool = createTool(defaultValueKey = null)
+        val tool = EnumTool(optionsProvider = StubOptionsProvider())
 
         assertFailsWith(NullPointerException::class) { tool.getDefaultValue() }
     }
@@ -25,6 +26,13 @@ class EnumToolTest : BaseTest() {
         val tool = createTool(defaultValueKey = "fourth-option")
 
         assertFailsWith(IllegalArgumentException::class) { tool.getDefaultValue() }
+    }
+
+    @Test
+    fun `uses field value in case an options provider was not provided`() {
+        val tool = EnumTool()
+
+        assertTrue(tool.options.isEmpty())
     }
 
     private fun createTool(

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolStoreTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolStoreTest.kt
@@ -3,6 +3,7 @@ package com.maximbircu.devtools.common.presentation.tools.group
 import com.maximbircu.devtools.common.mvp.BaseTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class GroupToolStoreTest : BaseTest() {
@@ -18,5 +19,19 @@ class GroupToolStoreTest : BaseTest() {
         val store = GroupToolStore()
 
         assertEquals(Unit, store.value)
+    }
+
+    @Test
+    fun `throws exception when trying to modify enabled value`() {
+        val store = GroupToolStore()
+
+        assertFailsWith<IllegalStateException> { store.isEnabled = false }
+    }
+
+    @Test
+    fun `throws exception when trying to modify configuration value`() {
+        val store = GroupToolStore()
+
+        assertFailsWith<IllegalStateException> { store.value = Unit }
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/group/GroupToolTest.kt
@@ -1,8 +1,11 @@
 package com.maximbircu.devtools.common.presentation.tools.group
 
+import com.maximbircu.devtools.common.core.createTool
 import com.maximbircu.devtools.common.mvp.BaseTest
+import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class GroupToolTest : BaseTest() {
     @Test
@@ -10,5 +13,15 @@ class GroupToolTest : BaseTest() {
         val tool = GroupTool(mapOf())
 
         assertFailsWith(IllegalArgumentException::class) { tool.getDefaultValue() }
+    }
+
+    @Test
+    fun `doesn't throw exception if the group has at least one tool`() {
+        GroupTool(mapOf("some-tool" to createTool<ToggleTool> { })).getDefaultValue()
+    }
+
+    @Test
+    fun `uses empty map as default value`() {
+        assertTrue(GroupTool().tools.isEmpty())
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/time/TimeToolPresenterImplTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/time/TimeToolPresenterImplTest.kt
@@ -21,10 +21,12 @@ class TimeToolPresenterImplTest : BasePresenterTest<TimeToolView, TimeToolPresen
 
     @Test
     fun `sets time when new time selected`() {
-        presenter.onToolBind(createTool {
-            ::title returns "Time Tool"
-            ::value returns 10000
-        })
+        presenter.onToolBind(
+            createTool {
+                ::title returns "Time Tool"
+                ::value returns 10000
+            }
+        )
 
         presenter.onTimeSelected(Time("1d 2h 3m 4s 5ms"))
 
@@ -33,10 +35,12 @@ class TimeToolPresenterImplTest : BasePresenterTest<TimeToolView, TimeToolPresen
 
     @Test
     fun `displays time selection dialog on click`() {
-        presenter.onToolBind(createTool {
-            ::title returns "Time Tool"
-            ::value returns 10000
-        })
+        presenter.onToolBind(
+            createTool {
+                ::title returns "Time Tool"
+                ::value returns 10000
+            }
+        )
 
         presenter.onClick("1d 2h 3m 4s 5ms")
 

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/time/TimeToolTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/presentation/tools/time/TimeToolTest.kt
@@ -11,4 +11,11 @@ class TimeToolTest : BaseTest() {
 
         assertEquals(93784005, tool.getDefaultValue())
     }
+
+    @Test
+    fun `uses default values`() {
+        val tool = TimeTool()
+
+        assertEquals(0, tool.getDefaultValue())
+    }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaDevToolFactoryProducerTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaDevToolFactoryProducerTest.kt
@@ -7,8 +7,9 @@ import com.maximbircu.devtools.common.readers.jsonschema.factories.JsonSchemaTex
 import com.maximbircu.devtools.common.readers.jsonschema.factories.JsonSchemaTextToolFactory
 import com.maximbircu.devtools.common.readers.jsonschema.factories.JsonSchemaTextToolIntegerFactory
 import com.maximbircu.devtools.common.readers.jsonschema.factories.JsonSchemaToggleToolFactory
-import kotlinx.serialization.json.json
-import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
@@ -16,7 +17,7 @@ import kotlin.test.assertTrue
 class JsonSchemaDevToolFactoryProducerTest : BaseTest() {
     @Test
     fun `creates toggle tool factory for boolean type`() {
-        val jsonObject = json { "type" to "boolean" }
+        val jsonObject = buildJsonObject { put("type", "boolean") }
         val factoryProducer = JsonSchemaDevToolFactoryProducer(jsonObject)
 
         assertTrue(factoryProducer.getDevToolFactory() is JsonSchemaToggleToolFactory)
@@ -24,7 +25,7 @@ class JsonSchemaDevToolFactoryProducerTest : BaseTest() {
 
     @Test
     fun `creates text tool factory for string type`() {
-        val jsonObject = json { "type" to "string" }
+        val jsonObject = buildJsonObject { put("type", "string") }
         val factoryProducer = JsonSchemaDevToolFactoryProducer(jsonObject)
 
         assertTrue(factoryProducer.getDevToolFactory() is JsonSchemaTextToolFactory)
@@ -32,7 +33,7 @@ class JsonSchemaDevToolFactoryProducerTest : BaseTest() {
 
     @Test
     fun `creates integer text tool factory for integer type`() {
-        val jsonObject = json { "type" to "integer" }
+        val jsonObject = buildJsonObject { put("type", "integer") }
         val factoryProducer = JsonSchemaDevToolFactoryProducer(jsonObject)
 
         assertTrue(factoryProducer.getDevToolFactory() is JsonSchemaTextToolIntegerFactory)
@@ -40,7 +41,7 @@ class JsonSchemaDevToolFactoryProducerTest : BaseTest() {
 
     @Test
     fun `creates double text tool factory for number type`() {
-        val jsonObject = json { "type" to "number" }
+        val jsonObject = buildJsonObject { put("type", "number") }
         val factoryProducer = JsonSchemaDevToolFactoryProducer(jsonObject)
 
         assertTrue(factoryProducer.getDevToolFactory() is JsonSchemaTextToolDoubleFactory)
@@ -48,9 +49,9 @@ class JsonSchemaDevToolFactoryProducerTest : BaseTest() {
 
     @Test
     fun `creates group tool factory for object type`() {
-        val jsonObject = json {
-            "type" to "object"
-            "properties" to json { }
+        val jsonObject = buildJsonObject {
+            put("type", "object")
+            putJsonObject("properties") {}
         }
         val factoryProducer = JsonSchemaDevToolFactoryProducer(jsonObject)
 
@@ -59,9 +60,9 @@ class JsonSchemaDevToolFactoryProducerTest : BaseTest() {
 
     @Test
     fun `creates enum tool factory when enum tag is present`() {
-        val jsonObject = json {
-            "type" to "string"
-            "enum" to jsonArray { }
+        val jsonObject = buildJsonObject {
+            put("type", "string")
+            putJsonObject("enum") { }
         }
         val factoryProducer = JsonSchemaDevToolFactoryProducer(jsonObject)
 
@@ -70,7 +71,7 @@ class JsonSchemaDevToolFactoryProducerTest : BaseTest() {
 
     @Test
     fun `throws exception in case the object type is not supported`() {
-        val jsonObject = json { "type" to "some not supported type" }
+        val jsonObject = buildJsonObject { put("type", "some not supported type") }
         val factoryProducer = JsonSchemaDevToolFactoryProducer(jsonObject)
 
         assertFailsWith(IllegalArgumentException::class) { factoryProducer.getDevToolFactory() }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaReaderTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaReaderTest.kt
@@ -38,6 +38,6 @@ class JsonSchemaReaderTest : BaseTest() {
                 }
               }
             }
-          """.trimIndent()
+        """.trimIndent()
     }
 }

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaToolFactoryTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/JsonSchemaToolFactoryTest.kt
@@ -3,7 +3,8 @@ package com.maximbircu.devtools.common.readers.jsonschema
 import com.maximbircu.devtools.common.mvp.BaseTest
 import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -12,13 +13,13 @@ import kotlin.test.assertTrue
 class JsonSchemaToolFactoryTest : BaseTest() {
     @Test
     fun `sets all required base tool properties in tool create`() {
-        val jsonObject = json {
-            "title" to "Tool title"
-            "description" to "Tool description"
-            "canBeDisabled" to false
-            "isEnabled" to true
-            "defaultEnabledValue" to true
-            "isCritical" to false
+        val jsonObject = buildJsonObject {
+            put("title", "Tool title")
+            put("description", "Tool description")
+            put("canBeDisabled", false)
+            put("isEnabled", true)
+            put("defaultEnabledValue", true)
+            put("isCritical", false)
         }
         val factory = JsonSchemaToolFactoryStub(jsonObject)
 

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaEnumToolFactoryTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaEnumToolFactoryTest.kt
@@ -1,8 +1,10 @@
 package com.maximbircu.devtools.common.readers.jsonschema.factories
 
 import com.maximbircu.devtools.common.mvp.BaseTest
-import kotlinx.serialization.json.json
-import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -15,12 +17,12 @@ class JsonSchemaEnumToolFactoryTest : BaseTest() {
 
     @Test
     fun `creates a proper enum dev tool with default value provided`() {
-        val enumToolJsonObject = json {
-            "default" to "Second Option"
-            "enum" to jsonArray {
-                +"First Option"
-                +"Second Option"
-                +"Third Option"
+        val enumToolJsonObject = buildJsonObject {
+            put("default", "Second Option")
+            putJsonArray("enum") {
+                add("First Option")
+                add("Second Option")
+                add("Third Option")
             }
         }
         val expectedOptions = enumValues.map { it to it }.toMap()
@@ -35,12 +37,12 @@ class JsonSchemaEnumToolFactoryTest : BaseTest() {
 
     @Test
     fun `creates a proper enum dev tool with allow custom flags provided`() {
-        val enumToolJsonObject = json {
-            "allowCustom" to true
-            "enum" to jsonArray {
-                +"First Option"
-                +"Second Option"
-                +"Third Option"
+        val enumToolJsonObject = buildJsonObject {
+            put("allowCustom", true)
+            putJsonArray("enum") {
+                add("First Option")
+                add("Second Option")
+                add("Third Option")
             }
         }
         val expectedOptions = enumValues.map { it to it }.toMap()
@@ -55,15 +57,15 @@ class JsonSchemaEnumToolFactoryTest : BaseTest() {
 
     @Test
     fun `creates a proper enum dev tool with default value and allow custom flags provided`() {
-        val enumToolJsonObject = json {
-            "title" to "Enum tool"
-            "default" to "Second Option"
-            "enum" to jsonArray {
-                +"First Option"
-                +"Second Option"
-                +"Third Option"
+        val enumToolJsonObject = buildJsonObject {
+            put("title", "Enum tool")
+            put("default", "Second Option")
+            putJsonArray("enum") {
+                add("First Option")
+                add("Second Option")
+                add("Third Option")
             }
-            "allowCustom" to true
+            put("allowCustom", true)
         }
         val expectedOptions = enumValues.map { it to it }.toMap()
         val factory = JsonSchemaEnumToolFactory(enumToolJsonObject)

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaGroupToolFactoryTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaGroupToolFactoryTest.kt
@@ -6,7 +6,7 @@ import com.maximbircu.devtools.common.mvp.BaseTest
 import com.maximbircu.devtools.common.readers.jsonschema.JsonSchemaToolFactory
 import com.maximbircu.devtools.common.utils.mockk
 import io.mockk.every
-import kotlinx.serialization.json.json
+import kotlinx.serialization.json.buildJsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -18,7 +18,7 @@ class JsonSchemaGroupToolFactoryTest : BaseTest() {
             "second-tool" to createTool()
         )
         val properties = expectedTools.map { (key, value) -> key to createSchemaToolFactory(value) }
-        val factory = JsonSchemaGroupToolFactory(json { }, properties.toMap())
+        val factory = JsonSchemaGroupToolFactory(buildJsonObject { }, properties.toMap())
 
         val tool = factory.create()
 

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolDoubleFactoryTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolDoubleFactoryTest.kt
@@ -2,14 +2,15 @@ package com.maximbircu.devtools.common.readers.jsonschema.factories
 
 import com.maximbircu.devtools.common.mvp.BaseTest
 import com.maximbircu.devtools.common.presentation.tools.text.TextTool
-import kotlinx.serialization.json.json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class JsonSchemaTextToolDoubleFactoryTest : BaseTest() {
     @Test
     fun `creates a proper text tool without default and hint values provided`() {
-        val jsonObject = json {}
+        val jsonObject = buildJsonObject {}
         val expectedTool = TextTool(default = 0.0)
         val factory = JsonSchemaTextToolDoubleFactory(jsonObject)
 
@@ -20,9 +21,7 @@ class JsonSchemaTextToolDoubleFactoryTest : BaseTest() {
 
     @Test
     fun `creates a proper text tool with default value provided`() {
-        val jsonObject = json {
-            "default" to 3.4
-        }
+        val jsonObject = buildJsonObject { put("default", 3.4) }
         val expectedTool = TextTool(default = 3.4)
         val factory = JsonSchemaTextToolDoubleFactory(jsonObject)
 
@@ -33,9 +32,7 @@ class JsonSchemaTextToolDoubleFactoryTest : BaseTest() {
 
     @Test
     fun `creates a proper text tool with hint value provided`() {
-        val jsonObject = json {
-            "hint" to "Floating point number config value"
-        }
+        val jsonObject = buildJsonObject { put("hint", "Floating point number config value") }
         val expectedTool = TextTool(
             default = 0.0,
             hint = "Floating point number config value"
@@ -49,9 +46,9 @@ class JsonSchemaTextToolDoubleFactoryTest : BaseTest() {
 
     @Test
     fun `creates a proper text tool with default and hint values provided`() {
-        val jsonObject = json {
-            "default" to 3.4
-            "hint" to "Floating point number config value"
+        val jsonObject = buildJsonObject {
+            put("default", 3.4)
+            put("hint", "Floating point number config value")
         }
         val expectedTool = TextTool(
             default = 3.4,

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolFactoryTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolFactoryTest.kt
@@ -2,14 +2,15 @@ package com.maximbircu.devtools.common.readers.jsonschema.factories
 
 import com.maximbircu.devtools.common.mvp.BaseTest
 import com.maximbircu.devtools.common.presentation.tools.text.TextTool
-import kotlinx.serialization.json.json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class JsonSchemaTextToolFactoryTest : BaseTest() {
     @Test
     fun `creates a proper text tool without default and hint values provided`() {
-        val jsonObject = json {}
+        val jsonObject = buildJsonObject {}
         val expectedTool = TextTool(default = "")
         val factory = JsonSchemaTextToolFactory(jsonObject)
 
@@ -20,9 +21,7 @@ class JsonSchemaTextToolFactoryTest : BaseTest() {
 
     @Test
     fun `creates a proper text tool with default value provided`() {
-        val jsonObject = json {
-            "default" to "String config value"
-        }
+        val jsonObject = buildJsonObject { put("default", "String config value") }
         val expectedTool = TextTool(default = "String config value")
         val factory = JsonSchemaTextToolFactory(jsonObject)
 
@@ -33,8 +32,8 @@ class JsonSchemaTextToolFactoryTest : BaseTest() {
 
     @Test
     fun `creates a proper text tool with hint value provided`() {
-        val jsonObject = json {
-            "hint" to "Floating point number config value"
+        val jsonObject = buildJsonObject {
+            put("hint", "Floating point number config value")
         }
         val expectedTool = TextTool(
             default = "",
@@ -49,9 +48,9 @@ class JsonSchemaTextToolFactoryTest : BaseTest() {
 
     @Test
     fun `creates a proper text tool with default and hint values provided`() {
-        val jsonObject = json {
-            "default" to "String config value"
-            "hint" to "Floating point number config value"
+        val jsonObject = buildJsonObject {
+            put("default", "String config value")
+            put("hint", "Floating point number config value")
         }
         val expectedTool = TextTool(
             default = "String config value",

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolIntegerFactoryTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaTextToolIntegerFactoryTest.kt
@@ -2,14 +2,15 @@ package com.maximbircu.devtools.common.readers.jsonschema.factories
 
 import com.maximbircu.devtools.common.mvp.BaseTest
 import com.maximbircu.devtools.common.presentation.tools.text.TextTool
-import kotlinx.serialization.json.json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class JsonSchemaTextToolIntegerFactoryTest : BaseTest() {
     @Test
     fun `creates a proper text tool without default and hint values provided`() {
-        val jsonObject = json {}
+        val jsonObject = buildJsonObject {}
         val expectedTool = TextTool(default = 0)
         val factory = JsonSchemaTextToolIntegerFactory(jsonObject)
 
@@ -20,8 +21,8 @@ class JsonSchemaTextToolIntegerFactoryTest : BaseTest() {
 
     @Test
     fun `creates a proper text tool with default value provided`() {
-        val jsonObject = json {
-            "default" to 3
+        val jsonObject = buildJsonObject {
+            put("default", 3)
         }
         val expectedTool = TextTool(default = 3)
         val factory = JsonSchemaTextToolIntegerFactory(jsonObject)
@@ -33,8 +34,8 @@ class JsonSchemaTextToolIntegerFactoryTest : BaseTest() {
 
     @Test
     fun `creates a proper text tool with hint value provided`() {
-        val jsonObject = json {
-            "hint" to "Floating point number config value"
+        val jsonObject = buildJsonObject {
+            put("hint", "Floating point number config value")
         }
         val expectedTool = TextTool(
             default = 0,
@@ -49,9 +50,9 @@ class JsonSchemaTextToolIntegerFactoryTest : BaseTest() {
 
     @Test
     fun `creates a proper text tool with default and hint values provided`() {
-        val jsonObject = json {
-            "default" to 3
-            "hint" to "Floating point number config value"
+        val jsonObject = buildJsonObject {
+            put("default", 3)
+            put("hint", "Floating point number config value")
         }
         val expectedTool = TextTool(
             default = 3,

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaToggleToolFactoryTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/jsonschema/factories/JsonSchemaToggleToolFactoryTest.kt
@@ -2,14 +2,15 @@ package com.maximbircu.devtools.common.readers.jsonschema.factories
 
 import com.maximbircu.devtools.common.mvp.BaseTest
 import com.maximbircu.devtools.common.presentation.tools.toggle.ToggleTool
-import kotlinx.serialization.json.json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class JsonSchemaToggleToolFactoryTest : BaseTest() {
     @Test
     fun `creates a proper enum dev tool without default value provided`() {
-        val jsonObject = json { }
+        val jsonObject = buildJsonObject { }
         val expectedTool = ToggleTool()
         val factory = JsonSchemaToggleToolFactory(jsonObject)
 
@@ -20,7 +21,7 @@ class JsonSchemaToggleToolFactoryTest : BaseTest() {
 
     @Test
     fun `creates a proper enum dev tool with default value provided`() {
-        val jsonObject = json { "default" to true }
+        val jsonObject = buildJsonObject { put("default", true) }
         val expectedTool = ToggleTool(default = true)
         val factory = JsonSchemaToggleToolFactory(jsonObject)
 

--- a/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/sources/JsonSchemaSourceTest.kt
+++ b/devtools/common/src/commonTest/kotlin/com/maximbircu/devtools/common/readers/sources/JsonSchemaSourceTest.kt
@@ -47,6 +47,6 @@ class JsonSchemaSourceTest : BaseTest() {
                 }
               }
             }
-          """.trimIndent()
+        """.trimIndent()
     }
 }

--- a/devtools/common/src/main/AndroidManifest.xml
+++ b/devtools/common/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.maximbircu.common" />

--- a/devtools/ios/DevtoolsFramework/DevToolsConfiguration.swift
+++ b/devtools/ios/DevtoolsFramework/DevToolsConfiguration.swift
@@ -1,9 +1,9 @@
 import devtools
 
 public final class DevToolsConfiguration {
-    public init(devTools: [String: DevTool]) {
+    public init(devTools: [String: DevTool<AnyObject>]) {
         initSource(devTools: devTools)
     }
 
-    private func initSource(devTools: [String: DevTool]) { }
+    private func initSource(devTools: [String: DevTool<AnyObject>]) { }
 }

--- a/devtools/ios/DevtoolsFramework/Presentation/DevToolPresentable.swift
+++ b/devtools/ios/DevtoolsFramework/Presentation/DevToolPresentable.swift
@@ -1,5 +1,5 @@
 import devtools
 
 public protocol DevToolPresentable: DevToolView {
-    func onBind(tool: DevTool)
+    func onBind(tool: DevTool<AnyObject>)
 }

--- a/devtools/ios/DevtoolsFramework/Presentation/DevToolView.swift
+++ b/devtools/ios/DevtoolsFramework/Presentation/DevToolView.swift
@@ -34,7 +34,7 @@ public class DevToolView: UIView, devtools.DevToolView, NibLoadable {
         return devToolView
     }
 
-    public func bind(tool: DevTool) {
+    public func bind(tool: DevTool<AnyObject>) {
         presenter.onToolBind(tool: tool)
         containerTool.onBind(tool: tool)
     }
@@ -43,7 +43,7 @@ public class DevToolView: UIView, devtools.DevToolView, NibLoadable {
         checkBox.isHidden = true
     }
 
-    public func refreshToolData(tool: DevTool) {
+    public func refreshToolData(tool: DevTool<AnyObject>) {
         bind(tool: tool)
     }
 
@@ -59,7 +59,7 @@ public class DevToolView: UIView, devtools.DevToolView, NibLoadable {
         checkBox.isHidden = false
     }
 
-    public func showHelpDialog(tool: DevTool) {
+    public func showHelpDialog(tool: DevTool<AnyObject>) {
 
     }
 

--- a/devtools/ios/DevtoolsFramework/Presentation/Tools/Toogle/ToggleView.swift
+++ b/devtools/ios/DevtoolsFramework/Presentation/Tools/Toogle/ToggleView.swift
@@ -29,7 +29,7 @@ public class ToggleView: DevToolView, DevToolPresentable, ToggleToolView {
         `switch`.setOn(value, animated: true)
     }
 
-    public func onBind(tool: DevTool) {
+    public func onBind(tool: DevTool<AnyObject>) {
         guard let tool = tool as? ToggleTool else { return }
         presenter.onToolBind(tool___: tool)
     }

--- a/devtools/ios/DevtoolsFramework/Readers/DevToolsSourcesExtensions.swift
+++ b/devtools/ios/DevtoolsFramework/Readers/DevToolsSourcesExtensions.swift
@@ -1,7 +1,7 @@
 import devtools
 
 public extension DevToolsSources {
-    static func memory(devTools: [String: DevTool]) -> DevToolsSource {
+    static func memory(devTools: [String: DevTool<AnyObject>]) -> DevToolsSource {
         return DevToolsSources().memory(devTools: devTools)
     }
 

--- a/devtools/ios/DevtoolsFramework/Readers/Sources/Yaml/Schema/YamlSchemaDevtoolProducer.swift
+++ b/devtools/ios/DevtoolsFramework/Readers/Sources/Yaml/Schema/YamlSchemaDevtoolProducer.swift
@@ -2,22 +2,22 @@ import devtools
 import Yams
 
 final class YamlSchemaDevtoolProducer {
-    static func createDevTool(yamlTag: String, config: Node.Mapping) -> DevTool? {
-        let devTool = parseToolByTag(yamlTag: yamlTag, config: config)
-        devTool?.title = config["title"]?.string
-        devTool?.description = config["description"]?.string ?? ""
-        devTool?.canBeDisabled = config["canBeDisabled"]?.bool ?? true
-        devTool?.defaultEnabledValue = config["defaultEnabledValue"]?.bool ?? false
-        devTool?.isCritical = config["isCritical"]?.bool ?? true
+    static func createDevTool(yamlTag: String, config: Node.Mapping) -> DevTool<AnyObject>? {
+        guard let devTool = parseToolByTag(yamlTag: yamlTag, config: config) as? DevTool<AnyObject> else { return nil }
+        devTool.title = config["title"]?.string
+        devTool.description_ = config["description"]?.string ?? ""
+        devTool.canBeDisabled = config["canBeDisabled"]?.bool ?? true
+        devTool.defaultEnabledValue = config["defaultEnabledValue"]?.bool ?? false
+        devTool.isCritical = config["isCritical"]?.bool ?? true
 
         return devTool
     }
 
-    private static func parseToolByTag(yamlTag: String, config: Node.Mapping) -> DevTool? {
+    private static func parseToolByTag(yamlTag: String, config: Node.Mapping) -> Any? {
         let toolDefaultValue = config["default"]
         switch yamlTag {
         case YamlDevToolsTypes.toggle.rawValue:
-            return ToggleTool(default: toolDefaultValue?.bool ?? false)
+            return ToggleTool(default: toolDefaultValue?.bool ?? false) as DevTool<KotlinBoolean>
         case YamlDevToolsTypes.text.rawValue:
             return TextTool(default: toolDefaultValue?.string ?? "", hint: config["hint"]?.string)
         case YamlDevToolsTypes.time.rawValue:
@@ -61,11 +61,11 @@ extension YamlSchemaDevtoolProducer {
 }
 
 extension YamlSchemaDevtoolProducer {
-    private static func parseGroup(tools: Node?) -> [String: DevTool] {
+    private static func parseGroup(tools: Node?) -> [String: DevTool<AnyObject>] {
         return tools?.mapping?.reduce(into: [String: DevTool]()) { result, node in
             guard let toolName = node.key.string,
                   let config = node.value.mapping else { return }
-            result[toolName] = parseToolByTag(yamlTag: node.value.tag.description, config: config)
+            result[toolName] = parseToolByTag(yamlTag: node.value.tag.description, config: config) as? DevTool<AnyObject>
         } ?? [:]
     }
 }

--- a/devtools/ios/DevtoolsFramework/Readers/Sources/Yaml/YamlDevToolsReader.swift
+++ b/devtools/ios/DevtoolsFramework/Readers/Sources/Yaml/YamlDevToolsReader.swift
@@ -8,16 +8,16 @@ final class YamlDevToolsReader: DevToolsReader {
         self.fileName = fileName
     }
 
-    func getDevTools() -> [String: DevTool] {
+    func getDevTools() -> [String: DevTool<AnyObject>] {
         return getTools()
     }
 
-    private func getTools() -> [String: DevTool] {
+    private func getTools() -> [String: DevTool<AnyObject>] {
         guard let node = try? Yams.compose(yaml: FileReader.readFile(fileName: fileName)) else { return [:] }
         return parseNode(node: node)
     }
 
-    private func parseNode(node: Node) -> [String: DevTool] {
+    private func parseNode(node: Node) -> [String: DevTool<AnyObject>] {
         return node.mapping?.reduce(into: [String: DevTool]()) { result, node in
             guard let devToolName = node.key.string,
                   let devTool = decodeDevTool(node: node.value) else { return }
@@ -25,7 +25,7 @@ final class YamlDevToolsReader: DevToolsReader {
         } ?? [:]
     }
 
-    private func decodeDevTool(node: Node) -> DevTool? {
+    private func decodeDevTool(node: Node) -> DevTool<AnyObject>? {
         guard let devToolConfig = node.mapping else { return nil }
         return YamlSchemaDevtoolProducer.createDevTool(yamlTag: node.tag.description, config: devToolConfig)
     }

--- a/documentation/configscreen/android-config-screen.md
+++ b/documentation/configscreen/android-config-screen.md
@@ -12,11 +12,20 @@ class DevToolsActivity: AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         val contentView = findViewById<ViewGroup>(android.R.id.content)
-        DevToolsConfigurationScreen.attachToView(contentView, MyApplication.application.devtools)
+        DevToolsConfigurationScreen.attachToView(
+            rootView = binding.devToolsContainer,
+            devTools = devtools,
+            configScreenRouter = object : ConfigurationScreenRouter {
+                override var onBack: (() -> Boolean)? = null
+
+                override fun closeScreen() = finish()
+            }
+        )
     }
 }
 ```
 You can attach this config screen view to any other view from your app.
+Note that `configScreenRouter` parameter is optional the library needs it to show a neat confirmation dialog when the config screen users will try to close the screen having unsaved changes.
 
 ## Theming
 The android library is based on material design. There is a [Theme.DevTools](../../devtools/android/src/main/res/values/styles.xml#L3) that you might extend inside your app to update the colors, text appearance, and shaping.

--- a/documentation/quickstart/quick-start-android.md
+++ b/documentation/quickstart/quick-start-android.md
@@ -109,12 +109,20 @@
     You just need to create a separate activity for the configuration screen and open it whenever you need to update your app config.
     
     ```Kotlin
-    class DevToolsActivity: AppCompatActivity() {
+    class DevToolsActivity: AppCompatActivity(), ConfigurationScreenRouter  {
         override fun onCreate(savedInstanceState: Bundle?) {
             super.onCreate(savedInstanceState)
     
             val contentView = findViewById<ViewGroup>(android.R.id.content)
-            DevToolsConfigurationScreen.attachToView(contentView, SampleApplication.application.devtools)
+             DevToolsConfigurationScreen.attachToView(
+                  rootView = binding.devToolsContainer,
+                  devTools = devtools,
+                  configScreenRouter = object : ConfigurationScreenRouter {
+                      override var onBack: (() -> Boolean)? = null
+      
+                      override fun closeScreen() = finish()
+                  }
+              )
         }
     }
     ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,24 +1,8 @@
-# Project-wide Gradle settings.
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app"s APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
-# Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+kotlin.mpp.stability.nowarn=true
 
 PROJECT_VERSION_NAME=1.0.1
 

--- a/gradle/detekt.gradle
+++ b/gradle/detekt.gradle
@@ -1,5 +1,9 @@
+allprojects {
+    apply plugin: "io.gitlab.arturbosch.detekt"
+}
+
 detekt {
-    toolVersion = "1.6.0"
+    toolVersion = "1.18.0-RC3"
     input = files("$rootDir")
     config = files("$rootDir/gradle/detekt.yml")
     reports {

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -2,8 +2,7 @@ allprojects {
     apply plugin: 'jacoco'
 
     jacoco {
-        toolVersion = "0.8.4"
-        reportsDir = file("$buildDir/reports")
+        toolVersion = "0.8.7"
     }
 
     ext.configureJacoco = { Closure getConfig ->
@@ -54,10 +53,6 @@ tasks.register("jacocoTestReport", JacocoReport) {
     reports {
         xml.enabled = true
         html.enabled = true
-    }
-
-    doFirst {
-        executionData.from = files(executionData.findAll { it.exists() })
     }
 }
 

--- a/gradle/ktlint.gradle
+++ b/gradle/ktlint.gradle
@@ -5,13 +5,18 @@ subprojects {
         }
 
         dependencies {
-            ktlint "com.pinterest:ktlint:0.36.0"
+            ktlint("com.pinterest:ktlint:0.42.1") {
+                attributes {
+                    attribute(Bundling.BUNDLING_ATTRIBUTE, getObjects().named(Bundling, Bundling.EXTERNAL))
+                }
+            }
         }
 
         task ktlint(type: JavaExec, group: "verification") {
             description = "Check Kotlin code style."
             classpath = configurations.ktlint
             main = "com.pinterest.ktlint.Main"
+            args "src/**/*.kt"
         }
 
         task ktlintFormat(type: JavaExec, group: "formatting") {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/android/build.gradle
+++ b/samples/android/build.gradle
@@ -51,10 +51,10 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-    implementation "com.google.android.material:material:1.3.0"
+    implementation "com.google.android.material:material:1.4.0"
     implementation 'com.google.code.gson:gson:2.8.6'
 
     // androidx
-    implementation "androidx.appcompat:appcompat:1.2.0"
+    implementation "androidx.appcompat:appcompat:1.3.1"
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
 }

--- a/samples/android/build.gradle
+++ b/samples/android/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "com.maximbircu.devtools"
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
 
@@ -56,5 +56,5 @@ dependencies {
 
     // androidx
     implementation "androidx.appcompat:appcompat:1.3.1"
-    implementation "androidx.constraintlayout:constraintlayout:2.0.4"
+    implementation "androidx.constraintlayout:constraintlayout:2.1.0"
 }

--- a/samples/android/src/main/AndroidManifest.xml
+++ b/samples/android/src/main/AndroidManifest.xml
@@ -12,7 +12,9 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="AllowBackup">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/samples/android/src/main/AndroidManifest.xml
+++ b/samples/android/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         tools:ignore="AllowBackup">
         <activity
             android:name=".MainActivity"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/YamlSourceConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/YamlSourceConfigActivity.kt
@@ -11,10 +11,8 @@ import com.maximbircu.devtools.android.DevToolsConfigurationScreen
 import com.maximbircu.devtools.common.presentation.configscreen.ConfigurationScreenRouter
 import com.maximbircu.devtools.databinding.ActivityToolsContainerBinding
 
-class YamlSourceConfigActivity : AppCompatActivity(), ConfigurationScreenRouter {
+class YamlSourceConfigActivity : AppCompatActivity() {
     private val devtools = SampleApplication.application.yamlDevTools
-
-    override var onBack: (() -> Boolean)? = null
 
     companion object {
         fun start(context: Context) {
@@ -38,14 +36,14 @@ class YamlSourceConfigActivity : AppCompatActivity(), ConfigurationScreenRouter 
             toast.show()
         }
 
-        DevToolsConfigurationScreen.attachToView(binding.devToolsContainer, devtools, this)
-    }
+        DevToolsConfigurationScreen.attachToView(
+            rootView = binding.devToolsContainer,
+            devTools = devtools,
+            configScreenRouter = object : ConfigurationScreenRouter {
+                override var onBack: (() -> Boolean)? = null
 
-    override fun closeScreen() {
-        finish()
-    }
-
-    override fun onBackPressed() {
-        if (onBack?.invoke() == false) super.onBackPressed()
+                override fun closeScreen() = finish()
+            }
+        )
     }
 }

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/YamlSourceConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/YamlSourceConfigActivity.kt
@@ -38,8 +38,6 @@ class YamlSourceConfigActivity : AppCompatActivity(), ConfigurationScreenRouter 
             toast.show()
         }
 
-
-
         DevToolsConfigurationScreen.attachToView(binding.devToolsContainer, devtools, this)
     }
 

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/YamlSourceConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/YamlSourceConfigActivity.kt
@@ -35,6 +35,13 @@ class YamlSourceConfigActivity : AppCompatActivity() {
             toast.show()
         }
 
-        DevToolsConfigurationScreen.attachToView(binding.devToolsContainer, devtools)
+
+
+        DevToolsConfigurationScreen.attachToView(
+            binding.devToolsContainer,
+            devtools
+        ) {
+            finish()
+        }
     }
 }

--- a/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/YamlSourceConfigActivity.kt
+++ b/samples/android/src/main/kotlin/com/maximbircu/devtools/configscreens/YamlSourceConfigActivity.kt
@@ -8,10 +8,13 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.maximbircu.devtools.SampleApplication
 import com.maximbircu.devtools.android.DevToolsConfigurationScreen
+import com.maximbircu.devtools.common.presentation.configscreen.ConfigurationScreenRouter
 import com.maximbircu.devtools.databinding.ActivityToolsContainerBinding
 
-class YamlSourceConfigActivity : AppCompatActivity() {
+class YamlSourceConfigActivity : AppCompatActivity(), ConfigurationScreenRouter {
     private val devtools = SampleApplication.application.yamlDevTools
+
+    override var onBack: (() -> Boolean)? = null
 
     companion object {
         fun start(context: Context) {
@@ -37,11 +40,14 @@ class YamlSourceConfigActivity : AppCompatActivity() {
 
 
 
-        DevToolsConfigurationScreen.attachToView(
-            binding.devToolsContainer,
-            devtools
-        ) {
-            finish()
-        }
+        DevToolsConfigurationScreen.attachToView(binding.devToolsContainer, devtools, this)
+    }
+
+    override fun closeScreen() {
+        finish()
+    }
+
+    override fun onBackPressed() {
+        if (onBack?.invoke() == false) super.onBackPressed()
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,5 @@
 rootProject.name = "devtools-library"
 
-enableFeaturePreview('GRADLE_METADATA')
-
 include ':devtools:common'
 include ':devtools:android'
 include ':devtools:ios'


### PR DESCRIPTION
Closes: #73

- [x] Unit tests  <!-- Check this if you covered your code with unit tests -->
- [x] Changelog <!-- Check this if you updated the changelog file  -->
- [x] Documentation (Readme) <!-- Check this if you updated the  documentation  -->

### What has been done
1. Implemented a discard dialog - in case the user will try to leave the configuration screen with unsaved changes the screen will not close and a discard dialog will be displayed instead. The dialog will be closed and the unsaved changes discarded in case the user will hit the OK button.
2. Updated some libraries including kotlinx-serialization and migrated to AGP 7
3. Update targetSdkVersion to 31

### Screenshots
Android | iOS
:-: | :-:
<img src="https://user-images.githubusercontent.com/12527390/128254499-391ed680-8a10-4a0b-b3e3-a6693dafa054.png" width=200>| Will be implemented later |

### How to test
U1
1. Open the sample app and open any dev tools configuration screen
2. Adjust any dev tool value
3. Don't hit the apply button and leave the screen by press the back button
4. Notice the discard dialog
5. Hit "CANCEL" or tap outside the dialog
6. Make sure the dialog closes and the configuration screen remains open

U2
1. Open the sample app and open any dev tools configuration screen
2. Adjust any dev tool value
3. Don't hit the apply button and leave the screen by press the back button
4. Notice the discard dialog
5. Hit "OK" 
6. Make sure the dialog and the configuration screen closes and the unsaved changes are reset
